### PR TITLE
PRJ-91: Prevent native zoom on mobile devices

### DIFF
--- a/projector-client-web/src/main/resources/index.html
+++ b/projector-client-web/src/main/resources/index.html
@@ -26,7 +26,8 @@
 <head>
   <title>Please wait...</title>
   <meta charset="UTF-8">
-
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
   <link href="pj.png" rel="shortcut icon" type="image/x-icon">
 
   <script src="https://cdn.jsdelivr.net/pako/1.0.3/pako.min.js"></script>
@@ -54,6 +55,11 @@
       }
     }
   </script>
+  <style>
+    body {
+      touch-action: none;
+    }
+  </style>
 </head>
 
 <body onload="onLoad()">


### PR DESCRIPTION
Refs [PRJ-91](https://youtrack.jetbrains.com/issue/PRJ-91)

This PR:
* Adds a common `meta` head element that prevents native zoom on < iOS10
* Adds a CSS rule that prevents native zoom/scroll for newer iOS versions
* Coincidentally, adds a `meta` head element that enables the webapp to be run full screen on iOS after 'Add to Home Screen' is used

Re the CSS rule:
* This is the only vanilla CSS declaration I could see in the project. I've added it as a plain old `style` tag with content; I'm not sure if you have a better/preferred solution for this codebase that I may have missed. Please let me know if I have!
* this disables native scroll as well as zoom. AFAICT native scroll does nothing useful in the webapp as it stands, so nothing is lost. If you want me to change this back to just block pinch-zoom, please let me know, though.