### PR TITLE
Partial correction of VersionControl/log blinking

### DIFF
--- a/projector-client-common/build.gradle.kts
+++ b/projector-client-common/build.gradle.kts
@@ -47,5 +47,18 @@ kotlin {
         api(kotlin("stdlib-js", kotlinVersion))
       }
     }
+
+    val commonTest by getting {
+      dependencies {
+        api(kotlin("test-common", kotlinVersion))
+        api(kotlin("test-annotations-common", kotlinVersion))
+      }
+    }
+
+    val jsTest by getting {
+      dependencies {
+        api(kotlin("test-js", kotlinVersion))
+      }
+    }
   }
 }

--- a/projector-client-common/src/commonMain/kotlin/org/jetbrains/projector/client/common/misc/ImageCacher.kt
+++ b/projector-client-common/src/commonMain/kotlin/org/jetbrains/projector/client/common/misc/ImageCacher.kt
@@ -44,7 +44,9 @@ object ImageCacher {
     val offscreenCanvas: Canvas.ImageSource
   )
 
-  private val cache = mutableMapOf<ImageId, LivingEntity<Canvas.ImageSource>>()
+  private val cache = mutableMapOf<ImageData, LivingEntity<Canvas.ImageSource>>()
+
+  private val imageDataByImageId = mutableMapOf<ImageId, ImageData>()
 
   private val requestedImages = mutableMapOf<ImageId, LivingEntity<Nothing?>>()
 
@@ -58,14 +60,23 @@ object ImageCacher {
   }
 
   fun putImageData(imageId: ImageId, imageData: ImageData, repainter: () -> Unit) {
-    putImageAsync(imageId, imageData, repainter)
+    requestedImages[imageId] = LivingEntity(TimeStamp.current, null) // Added new image to requested
+
+    if (imageData is ImageData.PngBase64) {
+      imageDataByImageId[imageId] = imageData
+    }
+
+    cache[imageData]?.apply { repainter() } ?: putImageAsync(imageId, imageData, repainter)
   }
 
   fun getImageData(imageId: ImageId): Canvas.ImageSource? = when (imageId) {
     is ImageId.PVolatileImageId -> offscreenImages[imageId.id]?.offscreenCanvas
 
     is ImageId.BufferedImageId -> {
-      val imageData = cache[imageId]?.apply { lastUsageTimestamp = TimeStamp.current }?.data
+      val imageData = imageDataByImageId[imageId]
+        ?.run(cache::get)
+        ?.apply { lastUsageTimestamp = TimeStamp.current }
+        ?.data
 
       if (imageData == null) {
         if (imageId !in requestedImages) {
@@ -120,7 +131,7 @@ object ImageCacher {
 
   private fun putImageAsync(imageId: ImageId, imageData: ImageData, repainter: () -> Unit) {
     fun onLoad(image: Canvas.ImageSource) {
-      cache[imageId] = LivingEntity(TimeStamp.current, image)
+      cache[imageData] = LivingEntity(TimeStamp.current, image)
       repainter()
     }
 

--- a/projector-client-common/src/commonTest/kotlin/org/jetbrains/projector/client/common/misc/ImageCacherTest.kt
+++ b/projector-client-common/src/commonTest/kotlin/org/jetbrains/projector/client/common/misc/ImageCacherTest.kt
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.projector.client.common.misc
+
+import org.jetbrains.projector.common.protocol.data.ImageData
+import org.jetbrains.projector.common.protocol.data.ImageId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ImageCacherTest {
+
+  private val imageId = ImageId.BufferedImageId(15, 1076959906)
+  private val imageData = ImageData.PngBase64("iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAA10lEQVR4XmNgGBQgKytLIjc31" +
+                                              "zcvL68eSG8E0s9BGMoGifmC1KDrgwOgov/EYHR9cICuEITz8/PFQTYDcR1ZBmCTRxZDAeia8SrGBtA1oxsQ" +
+                                              "sSJzbcziNElkMRQA1PAHnwGRKzL/A/F7IE5BFocDoIajRBgAw/tjVmWpIMszAEM8FJsBBQUFClgMAOFvkSu" +
+                                              "zyhz2N7AgGzIR2QCg5gAg/RyHAWAMDJs5cAOghhQDNf1CMugXDgMwXQADQEPUgXgbCOfk5GiAxNA0Y4YBIQ" +
+                                              "DViDsWCAF86QAAK0j+ypzY0swAAAAASUVORK5CYII=")
+
+  @Test
+  fun getImageDataShouldNotAddImageToRequestIfImageDataIsAlreadyConvertedFromBase64() {
+    ImageCacher.putImageData(imageId, imageData) {}
+
+    ImageCacher.getImageData(imageId)
+
+    assertEquals(0, ImageCacher.extractImagesToRequest().size)
+  }
+}

--- a/projector-common/src/commonMain/kotlin/org/jetbrains/projector/common/protocol/data/ImageId.kt
+++ b/projector-common/src/commonMain/kotlin/org/jetbrains/projector/common/protocol/data/ImageId.kt
@@ -33,9 +33,9 @@ sealed class ImageId {
   @SerialName("a")
   data class BufferedImageId(
     @SerialName("a")
-    val identityHash: Int,
+    val length: Int,
     @SerialName("b")
-    val stateHash: Int
+    val contentHash: Int
   ) : ImageId()
 
   @Serializable

--- a/projector-common/src/commonMain/kotlin/org/jetbrains/projector/common/protocol/data/ImageId.kt
+++ b/projector-common/src/commonMain/kotlin/org/jetbrains/projector/common/protocol/data/ImageId.kt
@@ -33,7 +33,7 @@ sealed class ImageId {
   @SerialName("a")
   data class BufferedImageId(
     @SerialName("a")
-    val length: Int,
+    val rasterDataBufferSize: Int,
     @SerialName("b")
     val contentHash: Int
   ) : ImageId()


### PR DESCRIPTION
I added new images to requestedImages to prevent double loading. And added caching of images by ImageData. Now, identical images with different ImageId are cached only once and are not converted many times from the same base64-strings.