### PR TITLE
Cache URLs in localStorage and support autocomplete

### DIFF
--- a/projector-launcher/src/main/resources/assets/js/main.js
+++ b/projector-launcher/src/main/resources/assets/js/main.js
@@ -21,6 +21,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+window.onload = function() {
+  document.getElementById("url-text-field").focus();
+};
+
+// Cache used URLs
+const storage = window.localStorage;
+const datalist = document.getElementById("url-data-list");
+const projectorLauncherStorageKey = "projector-launcher-urls"
+const results = (storage.getItem(projectorLauncherStorageKey)) ? JSON.parse(storage.getItem(projectorLauncherStorageKey)) : [];
+
+// Add cached URLs to the combobox datalist at start up
+results.forEach(result => addDataListOption(result))
+
+function addDataListOption(url) {
+  let option = document.createElement('option');
+  option.setAttribute('value', url);
+  option.innerText = url;
+  datalist.appendChild(option);
+}
+
 document.querySelector('#connect-button').addEventListener('click', function () {
   connect()
 });
@@ -33,8 +53,22 @@ document.querySelector('#url-text-field').addEventListener('keypress', function 
 
 function connect() {
   let url = document.getElementById("url-text-field").value;
+  if (isEmpty(url)) {
+    return;
+  }
+
   const {ipcRenderer} = require('electron')
   ipcRenderer.send("projector-connect", url);
+
+  cacheNewUrlValue(url);
+}
+
+function cacheNewUrlValue(url) {
+  if (results.indexOf(url) < 0) {
+    results.push(url);
+    storage.setItem(projectorLauncherStorageKey, JSON.stringify(results));
+    addDataListOption(url)
+  }
 }
 
 //$( document ).ready(function() {
@@ -44,3 +78,7 @@ ipcRenderer.on('projector-set-url', (event, arg) => {
   document.getElementById("url-text-field").value = arg
 })
 //});
+
+function isEmpty(str) {
+  return (!str || 0 === str.length);
+}

--- a/projector-launcher/src/main/resources/openurl.html
+++ b/projector-launcher/src/main/resources/openurl.html
@@ -36,7 +36,9 @@
       <div class="row">
         <div class="col-md-12" style="padding-bottom: 20px;">
           <div class="form-group">
-            <input aria-describedby="URL" class="form-control" id="url-text-field" placeholder="Connection URL" type="text">
+            <datalist id="url-data-list"></datalist>
+            <input aria-describedby="URL" class="form-control" id="url-text-field" placeholder="Connection URL" type="text"
+                   list="url-data-list">
             <small class="form-text text-muted" id="passwordHelpBlock">
               Standard URL template: http://void:8887/?host=void&port=8887
             </small>


### PR DESCRIPTION
A few usability improvements:
1. Cache previously used URLs in localStorage
2. Show the dropdown and autocompletion for cached URLs
3. Focus in url-text-field at the start

![autocomplete](https://user-images.githubusercontent.com/1669024/100060476-70e6d680-2de1-11eb-8c87-d090edb33c00.png)
