### PR TITLE
Fix context menu handling

### DIFF
--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/InputController.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/InputController.kt
@@ -205,6 +205,27 @@ class InputController(
     }
   }
 
+  // Translate a "oncontextmenu" event into a click with the right mouse button.
+  // "onclick" is only called for clicks with the left mouse button.
+  private fun handleContextMenuEvent(event: Event) {
+    require(event is MouseEvent)
+    event.preventDefault()
+
+    val topWindow = windowManager.getTopWindow(event.clientX, event.clientY) ?: return
+    if (topWindow.onMouseClick(event.clientX, event.clientY) == null) {
+      fireMouseEvent(
+        type = ClientMouseEvent.MouseEventType.CLICK,
+        windowId = topWindow.id,
+        eventTimeStamp = event.timeStamp,
+        x = event.clientX,
+        y = event.clientY,
+        button = 2, // 2 is the right mouse button
+        clickCount = event.detail,
+        modifiers = event.modifiers
+      )
+    }
+  }
+
   // This is extremely dangerous method, because it is called when mouse leave ANY canvas inside document!
   private fun handleMouseOutEvent(event: Event) {
     require(event is MouseEvent)
@@ -241,6 +262,7 @@ class InputController(
       "mousedown" to ::handleMouseDownEvent,
       "mouseup" to ::handleMouseUpEvent,
       "click" to ::handleClickEvent,
+      "contextmenu" to ::handleContextMenuEvent,
       "mouseout" to ::handleMouseOutEvent,
       "wheel" to ::fireWheelEvent
     ))

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/convert/toAwt/Mouse.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/convert/toAwt/Mouse.kt
@@ -143,7 +143,7 @@ public fun createMouseEvent(
     InputEvent.getMaskForButton(awtEventButton)
   }
 
-  val canTriggerPopup = awtEventButton == MouseEvent.BUTTON3
+  val canTriggerPopup = awtEventButton == MouseEvent.BUTTON3 && id == MouseEvent.MOUSE_PRESSED
 
   return MouseEvent(
     source,


### PR DESCRIPTION
On behalf of https://github.com/cdr.

This PR improves context menu handling inside of projector. 

Please note, that I have tested in a deployment of Coder, but was unable to test this with projector-docker. 
What's the best way to test changes to the client with projector-docker? I failed to get this to work.

1. Don't show a context menu twice: [For linux,](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.desktop/unix/classes/sun/awt/X11/XWindow.java#L714) the popup trigger happens only for right click (mouse button = 3) and when the mouse is PRESSED. 
When you observe carefully, then you'll notice that there's flicker when the context menu is opened in e.g. the project tree. That's caused by showing the menu twice.
2. Send "mouse clicked"  events for the right mouse button. In JavaScript, "click" only seems to be send for the left mouse button. Clicks with the right mouse button only triggered "mousedown" and "mouseup" events, but not a click.
In a JetBrains IDE, the terminal panel displays the popup menu only on click ([source](https://github.com/JetBrains/jediterm/blob/master/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java#L278)).
This PR sends a click event to the server when "oncontextmenu" is triggered. With this PR applied, the context menu in the terminal panel is displayed when clicking with the right mouse button.