### PR TITLE
Fix exceptions with Markdown plugin of 2020.3

### DIFF
--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ij/md/CssProcessor.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ij/md/CssProcessor.kt
@@ -37,7 +37,7 @@ internal object CssProcessor {
     appendLine(inlineCss.orEmpty())
 
     cssFileUrls.forEach {
-      it ?: return@forEach
+      if (it.isNullOrEmpty()) return@forEach
 
       try {
         val connection = URL(it).openConnection() as JarURLConnection
@@ -51,7 +51,7 @@ internal object CssProcessor {
         }
       }
       catch (t: Throwable) {
-        logger.error(t) { "Can't process file, skipping" }
+        logger.error(t) { "Can't process file '$it', skipping" }
       }
     }
   }

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ij/md/MarkdownPanelMaker.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ij/md/MarkdownPanelMaker.kt
@@ -114,6 +114,20 @@ public object MarkdownPanelMaker {
         )
       )
 
+      //added in JetBrains IDEs 2020.3+
+      //@Override
+      //@NotNull String html, int initialScrollOffset
+      addMethod(
+        CtNewMethod.make(
+          """
+            public void setHtml(String html, int initialScrollOffset) {
+              $delegateClass.getDeclaredMethod("setHtml", new Class[] { String.class, int.class }).invoke($delegate, new Object[] { html, Integer.valueOf(initialScrollOffset) });
+            }
+          """.trimIndent(),
+          this,
+        )
+      )
+
       //@Override
       //@Nullable String inlineCss, String... fileUris
       addMethod(

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ij/md/PanelDelegate.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ij/md/PanelDelegate.kt
@@ -147,6 +147,12 @@ internal class PanelDelegate {
     }
   }
 
+  // added in JetBrains IDEs, version 2020.3+
+  fun setHtml(html: String, initialScrollOffset: Int) {
+    setHtml(html)
+    scrollToMarkdownSrcOffset(initialScrollOffset)
+  }
+
   fun getComponent(): JComponent {
     return backingComponent
   }


### PR DESCRIPTION
On behalf of https://github.com/cdr

Fixes some of https://youtrack.jetbrains.com/issue/PRJ-226

When using 2020.3+ with Projector the following two exceptions are shown.
The first is caused by a new method in the Markdown panel. Rendering is broken without a fix (1st commit).

The second exception is caused because an empty CSS URL is passed (instead of `null`). It doesn't break rendering -- feel free to drop the commit if you don't want to merge it.

Please note, that the basic rendering is working again with this PR. But the styles are still not properly applied, because AFAIK 2020.3's markdown now uses an internal webserver and a different way to set the styles. Unfortunately I'm not sure how to fix this at this time.

Tested with IC 2020.3.2:
![Screenshot_026](https://user-images.githubusercontent.com/11473063/107749729-54d93e00-6d1b-11eb-839e-cdbb1e5cf3f6.png)


```
2021-02-12 08:55:06,936 [  37101]  ERROR - til.concurrency.QueueProcessor - Receiver class org.intellij.plugins.markdown.ui.preview.ProjectorMarkdownHtmlPanel does not define or inherit an implementation of the resolved method 'abstract void setHtml(java.lang.String, int)' of interface org.intellij.plugins.markdown.ui.preview.MarkdownHtmlPanel.
java.lang.AbstractMethodError: Receiver class org.intellij.plugins.markdown.ui.preview.ProjectorMarkdownHtmlPanel does not define or inherit an implementation of the resolved method 'abstract void setHtml(java.lang.String, int)' of interface org.intellij.plugins.markdown.ui.preview.MarkdownHtmlPanel.
        at org.intellij.plugins.markdown.ui.preview.MarkdownPreviewFileEditor.lambda$updateHtml$2(MarkdownPreviewFileEditor.java:315)
```

```
[ERROR] :: CssProcessor :: Can't process file, skipping :: java.net.MalformedURLException: no protocol:
        at java.base/java.net.URL.<init>(URL.java:645)
        at java.base/java.net.URL.<init>(URL.java:541)
        at java.base/java.net.URL.<init>(URL.java:488)
        at org.jetbrains.projector.server.core.ij.md.CssProcessor.makeCss(CssProcessor.kt:43)
        at org.jetbrains.projector.server.core.ij.md.PanelDelegate.setCSS(PanelDelegate.kt:127)
```