### PR TITLE
PRJ-235 Add option to bind to specific host address in the Projector …

### DIFF
--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ProjectorHttpWsServer.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ProjectorHttpWsServer.kt
@@ -27,8 +27,13 @@ import org.jetbrains.projector.common.protocol.toClient.MainWindow
 import org.jetbrains.projector.common.protocol.toClient.toJson
 import org.jetbrains.projector.server.core.util.GetRequestResult
 import org.jetbrains.projector.server.core.util.HttpWsServer
+import org.jetbrains.projector.server.core.util.getWildcardHostAddress
+import java.net.InetAddress
+import java.net.InetSocketAddress
 
-public abstract class ProjectorHttpWsServer(port: Int) : HttpWsServer(port) {
+public abstract class ProjectorHttpWsServer(host: InetAddress, port: Int) : HttpWsServer(host, port) {
+
+  public constructor(port: Int) : this(getWildcardHostAddress(), port)
 
   private companion object {
 

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/util/HostAddress.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/util/HostAddress.kt
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.projector.server.core.util
+
+import java.net.InetAddress
+import java.net.InetSocketAddress
+
+public fun getWildcardHostAddress(): InetAddress = InetSocketAddress(0).getAddress()

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/util/HttpWsServer.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/util/HttpWsServer.kt
@@ -34,6 +34,7 @@ import org.java_websocket.framing.Framedata
 import org.java_websocket.handshake.*
 import org.java_websocket.server.WebSocketServer
 import org.java_websocket.util.Charsetfunctions
+import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.util.concurrent.locks.ReentrantLock
@@ -49,7 +50,9 @@ public class GetRequestResult(
 
 private val ClientHandshake.isHttp: Boolean get() = this.getFieldValue("Upgrade").isNullOrBlank()
 
-public abstract class HttpWsServer(port: Int) {
+public abstract class HttpWsServer(host: InetAddress, port: Int) {
+
+  public constructor(port: Int) : this(getWildcardHostAddress(), port)
 
   private inner class HttpDraft : Draft() {
 
@@ -122,7 +125,7 @@ public abstract class HttpWsServer(port: Int) {
     }
   }
 
-  private val webSocketServer = object : WebSocketServer(InetSocketAddress(port), listOf(HttpDraft(), Draft_6455())) {
+  private val webSocketServer = object : WebSocketServer(InetSocketAddress(host, port), listOf(HttpDraft(), Draft_6455())) {
 
     @Volatile
     private var wasInitialized: Boolean? = null


### PR DESCRIPTION
…WebSocket server

`ProjectorHttpWsServer` and `HttpWsServer` can be instantiated with a `InetAddress` specifying the host address on which it will listen.