### PR TITLE
update cask command

### DIFF
--- a/projector-launcher/README.md
+++ b/projector-launcher/README.md
@@ -17,7 +17,7 @@ Please check out [documentation](https://jetbrains.github.io/projector-client/mk
 - If your OS is not Windows you must install Wine:
     - Mac: 
         - `brew cask install xquartz`
-        - `brew cask install wine-stable`
+        - `brew install --cask --no-quarantine wine-stable`
     - Ubuntu, Debian: `apt install wine-stable`
     - ArchLinux: `pacman -S wine`
     - Fedora:


### PR DESCRIPTION
This original cask command gave the error `cask not found` - going to winehq website shows that this is the command needed. 

```bash
christianb@christianb-mac thetaone % brew -v
Homebrew 3.0.7
Homebrew/homebrew-core (git revision f925caa10d; last commit 2021-03-19)
Homebrew/homebrew-cask (git revision b8f8961cb5; last commit 2021-03-19)
```