### PR TITLE
PRJ-413 Check if current window runs inside iframe

### DIFF
--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/layout/KeyboardApiLayout.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/layout/KeyboardApiLayout.kt
@@ -31,6 +31,7 @@ import org.jetbrains.projector.common.protocol.data.VK
 object KeyboardApiLayout {
 
   suspend fun getVirtualKey(code: String): VK? {
+    if (window != window.parent) return null
     val keyboard = window.navigator.keyboard ?: return null
     val currentLayout = keyboard.getLayoutMap().await()
     val currentSymbolOnKeyboard = currentLayout.get(code)?.single()


### PR DESCRIPTION
#### Description:
This change proposal adds an additional check for window that runs inside iframe.
The main problem which this fix provides occurs by handling key events. After trying to enter any key browser warned with such exceptions:

![Projector web client inside iframe 2021-03-31 01-37-00](https://user-images.githubusercontent.com/1968177/113367563-f87ebc00-9364-11eb-9a01-f0b4cea27f4e.jpg)

#### Steps to reproduce this problem:
- Create the html page with the following content:
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <title>Projector web client inside iframe</title>
</head>
<body>
    <iframe src="http://localhost:8887" style="width: 1024px; height: 720px; padding: 10px; background: black"></iframe>
</body>
</html>
```
- Run docker container `docker run --rm -p 8887:8887 -it <container_image>`
- Open above html page and try to type something

#### Steps to check current changes:
- Build and run `projector-web-client` in development mode
- Create the html page with the following content:
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <title>Projector web client inside iframe</title>
</head>
<body>
    <iframe src="http://localhost:8080/?host=localhost&port=8887" style="width: 1024px; height: 720px; padding: 10px; background: black"></iframe>
</body>
</html>
```
- Run docker container `docker run --rm -p 8887:8887 -it <container_image>`
- Open above html page and try to type something, key events should be successfully handled without any exception.

fixes https://youtrack.jetbrains.com/issue/PRJ-413

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>