### PR TITLE
web: rewrite events for opening localhost

### DIFF
--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/ServerEventsProcessor.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/ServerEventsProcessor.kt
@@ -36,6 +36,7 @@ import org.jetbrains.projector.client.web.window.WindowDataEventsProcessor
 import org.jetbrains.projector.common.misc.Do
 import org.jetbrains.projector.common.protocol.toClient.*
 import org.jetbrains.projector.util.logging.Logger
+import org.w3c.dom.url.URL
 
 class ServerEventsProcessor(private val windowDataEventsProcessor: WindowDataEventsProcessor) {
 
@@ -117,8 +118,16 @@ class ServerEventsProcessor(private val windowDataEventsProcessor: WindowDataEve
       .catch { logger.error { "Error writing clipboard: $it" } }
   }
 
+
   private fun browseUri(link: String) {
-    val popUpWindow = window.open(link, "_blank")
+    val url = URL(link)
+
+    if(url.hostname == "localhost" || url.hostname == "127.0.0.1" || url.host == "::1") {
+      url.hostname = window.location.hostname
+      url.protocol = window.location.protocol
+    }
+
+    val popUpWindow = window.open(url.href, "_blank")
 
     if (popUpWindow != null) {
       popUpWindow.focus()  // browser has allowed it to be opened


### PR DESCRIPTION
Rewrites requets to open localhost to the current location of projector.
This allows for use cases where the ide wants to open a localhost like
but the port is accessible on the same ip/hostname as projector.
Especially useful when the integrated webserver is configured to accept
external connections.
