### PR TITLE
PRJ-513 Use Jsoup for parsing html representation of markdown documents

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,7 @@ inlineStylePrefixerVersion=~6.0.0
 javassistVersion=3.27.0-GA
 javaWebSocketVersion=1.5.1
 jqueryVersion=3.5.1
+jsoupVersion=1.13.1
 kotlinVersion=1.4.20
 kotlinExtensionsVersion=1.0.1-pre.129-kotlin-1.4.10
 kotlinReactVersion=16.14.0-pre.125-kotlin-1.4.10

--- a/projector-server-core/build.gradle.kts
+++ b/projector-server-core/build.gradle.kts
@@ -47,6 +47,7 @@ val coroutinesVersion: String by project
 val dnsjavaVersion: String by project
 val javassistVersion: String by project
 val javaWebSocketVersion: String by project
+val jsoupVersion: String by project
 val kotlinVersion: String by project
 val ktorVersion: String by project
 val selenideVersion: String by project
@@ -130,6 +131,7 @@ dependencies {
   api("org.java-websocket:Java-WebSocket:$javaWebSocketVersion")
   implementation("org.slf4j:slf4j-simple:$slf4jVersion")
   implementation("dnsjava:dnsjava:$dnsjavaVersion")
+  implementation("org.jsoup:jsoup:$jsoupVersion")
 
   // todo: remove these dependencies: they should be exported from projector-common but now it seems not working
   testImplementation(kotlin("test", kotlinVersion))


### PR DESCRIPTION
This changes proposal provides the parsing html representation for markdown documents using Jsoup library instead of default Java xml parsing mechanism. Full description of problem provided in upstream issue: https://youtrack.jetbrains.com/issue/PRJ-513

Current rendering state in master for some complex markdown document:
![theia – README md 2021-05-19 13-25-57](https://user-images.githubusercontent.com/1968177/118800932-1f5b6800-b8a9-11eb-9cfa-bffd2d252f19.jpg)

With provided fix:
![theia – README md 2021-05-19 13-36-43](https://user-images.githubusercontent.com/1968177/118801040-3f8b2700-b8a9-11eb-9e66-1a12acd8b28d.jpg)

cc @SerVB 

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>