### PR TITLE
PRJ-241 Considered the current browser path when constructing the URL…

### DIFF
--- a/projector-client-common/src/jsMain/kotlin/org/jetbrains/projector/client/common/misc/ParamsProvider.kt
+++ b/projector-client-common/src/jsMain/kotlin/org/jetbrains/projector/client/common/misc/ParamsProvider.kt
@@ -34,6 +34,8 @@ actual object ParamsProvider {
     else -> hostname
   }
 
+  private fun getCurrentPath(): String = window.location.pathname
+
   private fun protocolPort(): String {
     return if (window.location.protocol == "https:") "443" else "80"
   }
@@ -45,6 +47,7 @@ actual object ParamsProvider {
 
   private val DEFAULT_HOST = getCurrentHostname()
   private val DEFAULT_PORT = getCurrentPort()
+  private val DEFAULT_PATH = getCurrentPath()
   private val DEFAULT_TO_CLIENT_FORMAT: ToClientFormat = ToClientFormat.KOTLINX_JSON_MANUAL
   private const val DEFAULT_IMAGE_TTL = 60_000.0  // in ms
   private const val DEFAULT_FLUSH_DELAY = 1
@@ -64,6 +67,7 @@ actual object ParamsProvider {
   actual val CLIPPING_BORDERS: Boolean
   val HOST: String
   val PORT: String
+  val PATH: String
   val RELAY_SERVER_ID: String?
   val ENABLE_RELAY: Boolean get() = RELAY_SERVER_ID != null
   actual val LOG_UNSUPPORTED_EVENTS: Boolean
@@ -99,6 +103,7 @@ actual object ParamsProvider {
       CLIPPING_BORDERS = searchParams.has("clipping")
       HOST = searchParams.get("host") ?: DEFAULT_HOST
       PORT = searchParams.get("port") ?: if (ENABLE_RELAY) protocolPort() else DEFAULT_PORT
+      PATH = DEFAULT_PATH
       LOG_UNSUPPORTED_EVENTS = searchParams.has("logUnsupportedEvents")
       DOUBLE_BUFFERING = searchParams.has("doubleBuffering")
       ENABLE_COMPRESSION = searchParams.has("enableCompression")

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/Application.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/Application.kt
@@ -58,7 +58,7 @@ class Application {
       false -> ""
     }
 
-    val url = "$scheme$host$port$path"
+    val url = "$scheme$host$port${ParamsProvider.PATH}$path"
 
     try {
       setClipboardPermissions()


### PR DESCRIPTION
… for the websocket so that we can run behind a reverse proxy

https://youtrack.jetbrains.com/issue/PRJ-241