### PR TITLE
Added 'enableRemoteModule' parameter to fix Spectron test issue

### DIFF
--- a/projector-launcher/src/main/kotlin/ElectronApp.kt
+++ b/projector-launcher/src/main/kotlin/ElectronApp.kt
@@ -70,6 +70,7 @@ class ElectronApp(val url: String) {
                     height: height,
                     webPreferences: {
                         nodeIntegration: true,
+                        enableRemoteModule: true,
                         webSecurity: false,
                         worldSafeExecuteJavaScript: true,
                         preload: preloadPath


### PR DESCRIPTION
Added a new option that is [required](https://github.com/electron-userland/spectron/issues/720#issuecomment-743950042) in the new versions of Electron & Spectron to be able to test the app
