### PR TITLE
Skip speculative rendering of potentially invisible inputted chars

### DIFF
--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/speculative/Typing.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/speculative/Typing.kt
@@ -116,7 +116,7 @@ sealed class Typing {
      * - Chars inputted with any of Ctrl/Alt/Meta modifiers (Example: Ctrl+C)
      * - Chars with Unicode category from "Other" group (Example: Esc or Meta)
      */
-    private fun shouldSkipEvent(event: ClientKeyPressEvent): Boolean {
+    internal fun shouldSkipEvent(event: ClientKeyPressEvent): Boolean {
       return KeyModifier.CTRL_KEY in event.modifiers
              || KeyModifier.ALT_KEY in event.modifiers
              || KeyModifier.META_KEY in event.modifiers

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/speculative/Typing.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/speculative/Typing.kt
@@ -27,6 +27,8 @@ import kotlinx.browser.document
 import org.jetbrains.projector.client.common.canvas.Extensions.toFontFaceName
 import org.jetbrains.projector.client.common.misc.ParamsProvider.SCALING_RATIO
 import org.jetbrains.projector.common.protocol.toClient.ServerCaretInfoChangedEvent
+import org.jetbrains.projector.common.protocol.toServer.ClientKeyPressEvent
+import org.jetbrains.projector.common.protocol.toServer.KeyModifier
 import org.w3c.dom.CanvasRenderingContext2D
 import org.w3c.dom.HTMLCanvasElement
 
@@ -36,7 +38,7 @@ sealed class Typing {
 
   abstract fun removeSpeculativeImage()
 
-  abstract fun addChar(char: Char)
+  abstract fun addEventChar(event: ClientKeyPressEvent)
 
   abstract fun dispose()
 
@@ -50,7 +52,7 @@ sealed class Typing {
       // do nothing
     }
 
-    override fun addChar(char: Char) {
+    override fun addEventChar(event: ClientKeyPressEvent) {
       // do nothing
     }
 
@@ -107,7 +109,23 @@ sealed class Typing {
       updateCanvas()
     }
 
-    override fun addChar(char: Char) {
+    /**
+     * Skip drawing speculative symbol when we cannot be sure char will be actually drawn on the server.
+     * Potentially invisible inputted chars:
+     *
+     * - Chars inputted with any of Ctrl/Alt/Meta modifiers (Example: Ctrl+C)
+     * - Chars with Unicode category from "Other" group (Example: Esc or Meta)
+     */
+    private fun shouldSkipEvent(event: ClientKeyPressEvent): Boolean {
+      return KeyModifier.CTRL_KEY in event.modifiers
+             || KeyModifier.ALT_KEY in event.modifiers
+             || KeyModifier.META_KEY in event.modifiers
+             || event.char.category.fromOtherUnicodeGroup
+    }
+
+    override fun addEventChar(event: ClientKeyPressEvent) {
+      if (shouldSkipEvent(event)) return
+
       val currentCarets = carets as? ServerCaretInfoChangedEvent.CaretInfoChange.Carets ?: return
 
       val canvas = canvasByIdGetter(currentCarets.editorWindowId) ?: return
@@ -148,7 +166,7 @@ sealed class Typing {
         fillStyle = "#888"  // todo: use a proper color
 
         val stringYPos = firstCaretLocation.y + currentCarets.fontSize  // todo: offsetting by fontSize seems to be not exact
-        fillText(char.toString(), firstCaretLocation.x, stringYPos)
+        fillText(event.char.toString(), firstCaretLocation.x, stringYPos)
       }
 
       speculativeCanvasImage.style.display = "block"

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/speculative/TypingUtils.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/speculative/TypingUtils.kt
@@ -1,0 +1,32 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.projector.client.web.speculative
+
+internal val CharCategory.fromOtherUnicodeGroup: Boolean
+  get() = this == CharCategory.UNASSIGNED
+          || this == CharCategory.CONTROL
+          || this == CharCategory.FORMAT
+          || this == CharCategory.PRIVATE_USE
+          || this == CharCategory.SURROGATE
+

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
@@ -500,7 +500,7 @@ sealed class ClientState {
         val event = action.event
 
         if (event is ClientKeyPressEvent) {
-          typing.addChar(event.char)
+          typing.addEventChar(event)
         }
 
         eventsToSend.add(event)

--- a/projector-client-web/src/test/kotlin/org/jetbrains/projector/client/web/speculative/TypingTest.kt
+++ b/projector-client-web/src/test/kotlin/org/jetbrains/projector/client/web/speculative/TypingTest.kt
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.projector.client.web.speculative
+
+import org.jetbrains.projector.common.protocol.toServer.ClientKeyPressEvent
+import org.jetbrains.projector.common.protocol.toServer.KeyModifier
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TypingTest {
+
+  private val typing = Typing.SpeculativeTyping { null }
+
+  @Suppress("TestFunctionName")
+  private fun KeyPressed(char: Char, vararg modifiers: KeyModifier) = ClientKeyPressEvent(0, char, setOf(*modifiers))
+
+  @Test
+  fun testSpeculativeTypingFiltering() {
+
+    listOf(
+      KeyPressed('a')                               /* Just a regular char */                 to false, // Category: LOWERCASE_LETTER
+      KeyPressed('B',       KeyModifier.CTRL_KEY)                                             to true,  // Category: UPPERCASE_LETTER
+      KeyPressed('1',       KeyModifier.ALT_KEY)                                              to true,  // Category: DECIMAL_DIGIT_NUMBER
+      KeyPressed('(',       KeyModifier.META_KEY)                                             to true,  // Category: START_PUNCTUATION
+      KeyPressed(')',       KeyModifier.REPEAT)                                               to false, // Category: END_PUNCTUATION
+      KeyPressed(',',       KeyModifier.SHIFT_KEY)                                            to false, // Category: OTHER_PUNCTUATION
+      KeyPressed('+',       KeyModifier.CTRL_KEY, KeyModifier.META_KEY)                       to true,  // Category: MATH_SYMBOL
+      KeyPressed('-',       KeyModifier.CTRL_KEY, KeyModifier.ALT_KEY, KeyModifier.META_KEY)  to true,  // Category: DASH_PUNCTUATION
+      KeyPressed('`',       KeyModifier.CTRL_KEY, KeyModifier.SHIFT_KEY)                      to true,  // Category: MODIFIER_SYMBOL
+      KeyPressed(' ',       KeyModifier.REPEAT, KeyModifier.SHIFT_KEY)                        to false, // Category: SPACE_SEPARATOR
+      KeyPressed('\u0000')                          /* <Null> */                              to true,  // Category: CONTROL
+      KeyPressed('\u001B',  KeyModifier.CTRL_KEY)   /* <Escape> */                            to true,  // Category: CONTROL
+      KeyPressed('\n',      KeyModifier.META_KEY, KeyModifier.ALT_KEY)                        to true,  // Category: CONTROL
+      KeyPressed('\r',      KeyModifier.SHIFT_KEY)                                            to true,  // Category: CONTROL
+      KeyPressed('\uFEFF',  KeyModifier.REPEAT)     /* BOM */                                 to true,  // Category: FORMAT
+      KeyPressed('\uFFFF')                          /* Undefined Character */                 to true,  // Category: UNASSIGNED
+    ).forEachIndexed { index, (event, expected) ->
+
+      val result = typing.shouldSkipEvent(event)
+      assertEquals(expected, result, "Differs at index $index for event $event")
+    }
+
+  }
+
+}


### PR DESCRIPTION
Potentially invisible inputted chars:

- Chars with unicode category from "Other" group: UNASSIGNED (Cn), CONTROL (https://www.compart.com/en/unicode/category/Cc), FORMAT (https://www.compart.com/en/unicode/category/Cf), PRIVATE_USE (Co), SURROGATE (Cs)  (Example: pressing Esc or Meta  produced rendering of invalid char)
- Chars inputted with any of Ctrl/Alt/Meta modifiers (Example: Ctrl+C produced rendering of 'c')