### PR TITLE
Ci license year check

### DIFF
--- a/.github/workflows/license-year-check.yml
+++ b/.github/workflows/license-year-check.yml
@@ -1,0 +1,21 @@
+name: Update copyright year in license files
+
+on:
+  schedule:
+    - cron: "0 3 1 1 *"
+
+jobs:
+  update-license-year:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions:checkout@v2
+        with:
+          fetch-dept: 0
+      - uses: FantasticFiasco/action-update-license-year@v2
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: |
+            ./LICENSE.txt
+            ./**/*.kt
+            ./**/*.kts
+            ./*.kts


### PR DESCRIPTION
license checker will update year in copyright headers on 03:00 1st January every year

[proof](https://github.com/Avvessalom/test-project/pull/11)