### PR TITLE
Get rid of md plugin requirement

### DIFF
--- a/projector-agent-ij-injector/src/main/kotlin/org/jetbrains/projector/agent/ijInjector/IjMdTransformer.kt
+++ b/projector-agent-ij-injector/src/main/kotlin/org/jetbrains/projector/agent/ijInjector/IjMdTransformer.kt
@@ -29,6 +29,7 @@ import org.jetbrains.projector.agent.common.getClassFromClassfileBuffer
 import org.jetbrains.projector.agent.init.IjArgs
 import org.jetbrains.projector.util.logging.Logger
 import java.lang.instrument.ClassFileTransformer
+import java.lang.reflect.InvocationTargetException
 import java.security.ProtectionDomain
 
 internal class IjMdTransformer private constructor(
@@ -127,7 +128,12 @@ internal class IjMdTransformer private constructor(
       logger.debug { "IjMdTransformer agentmain start" }
 
       val extensionPointName = utils.createExtensionPointName(MD_EXTENSION_ID)
-      val extensions = utils.extensionPointNameGetExtensions(extensionPointName)
+      val extensions = try {
+        utils.extensionPointNameGetExtensions(extensionPointName)
+      } catch (e: InvocationTargetException) {
+        logger.debug { "Markdown plugin is not installed. Skip the transform" }
+        return
+      }
 
       val mdClassloader = extensions.filterNotNull().first()::class.java.classLoader
 


### PR DESCRIPTION
Markdown plugin is not installed on some IDEA-based IDE (such as Android Studio). For `IjMdTransformer`, we should capture the exception if the markdown plugin is not installed. For other transforms, it is safer to use searcheverywhere EP instead since there should be at least one implementation from the IDE itself.