### PR TITLE
Show text overlay on the correct place for IME (PRJ-510)

### DIFF
--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/ServerEventsProcessor.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/ServerEventsProcessor.kt
@@ -27,6 +27,7 @@ import kotlinx.browser.window
 import org.jetbrains.projector.client.common.SingleRenderingSurfaceProcessor.Companion.shrinkByPaintEvents
 import org.jetbrains.projector.client.common.misc.ImageCacher
 import org.jetbrains.projector.client.web.component.MarkdownPanelManager
+import org.jetbrains.projector.client.web.input.InputController
 import org.jetbrains.projector.client.web.misc.PingStatistics
 import org.jetbrains.projector.client.web.speculative.Typing
 import org.jetbrains.projector.client.web.state.ProjectorUI
@@ -35,7 +36,6 @@ import org.jetbrains.projector.client.web.window.WindowDataEventsProcessor
 import org.jetbrains.projector.common.misc.Do
 import org.jetbrains.projector.common.protocol.toClient.*
 import org.jetbrains.projector.util.logging.Logger
-import org.jetbrains.projector.client.web.input.InputController
 import org.w3c.dom.url.URL
 
 class ServerEventsProcessor(private val windowDataEventsProcessor: WindowDataEventsProcessor) {
@@ -59,7 +59,10 @@ class ServerEventsProcessor(private val windowDataEventsProcessor: WindowDataEve
           command.imageData,
         )
 
-        is ServerCaretInfoChangedEvent -> typing.changeCaretInfo(command.data)
+        is ServerCaretInfoChangedEvent -> {
+          typing.changeCaretInfo(command.data)
+          inputController.handleCaretInfoChange(command.data)
+        }
 
         is ServerClipboardEvent -> handleServerClipboardChange(command)
 
@@ -83,7 +86,6 @@ class ServerEventsProcessor(private val windowDataEventsProcessor: WindowDataEve
           OnScreenMessenger.lookAndFeelChanged()
         }
       }
-      inputController.handleServerEvent(command)
     }
 
     // todo: determine the moment better

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/ServerEventsProcessor.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/ServerEventsProcessor.kt
@@ -35,12 +35,14 @@ import org.jetbrains.projector.client.web.window.WindowDataEventsProcessor
 import org.jetbrains.projector.common.misc.Do
 import org.jetbrains.projector.common.protocol.toClient.*
 import org.jetbrains.projector.util.logging.Logger
+import org.jetbrains.projector.client.web.input.InputController
 import org.w3c.dom.url.URL
 
 class ServerEventsProcessor(private val windowDataEventsProcessor: WindowDataEventsProcessor) {
 
   @OptIn(ExperimentalStdlibApi::class)
-  fun process(commands: ToClientMessageType, pingStatistics: PingStatistics, typing: Typing, markdownPanelManager: MarkdownPanelManager) {
+  fun process(commands: ToClientMessageType, pingStatistics: PingStatistics, typing: Typing, markdownPanelManager: MarkdownPanelManager,
+              inputController: InputController) {
     val drawCommandsEvents = mutableListOf<ServerDrawCommandsEvent>()
 
     commands.forEach { command ->
@@ -81,6 +83,7 @@ class ServerEventsProcessor(private val windowDataEventsProcessor: WindowDataEve
           OnScreenMessenger.lookAndFeelChanged()
         }
       }
+      inputController.handleServerEvent(command)
     }
 
     // todo: determine the moment better

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/InputController.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/InputController.kt
@@ -35,6 +35,8 @@ import org.jetbrains.projector.client.web.state.ClientStateMachine
 import org.jetbrains.projector.client.web.window.DragEventsInterceptor
 import org.jetbrains.projector.client.web.window.WindowManager
 import org.jetbrains.projector.common.protocol.toServer.*
+import org.jetbrains.projector.common.protocol.toClient.ServerEvent
+import org.jetbrains.projector.common.protocol.toClient.ServerCaretInfoChangedEvent
 import org.w3c.dom.TouchEvent
 import org.w3c.dom.clipboard.ClipboardEvent
 import org.w3c.dom.events.Event
@@ -386,6 +388,12 @@ class InputController(
 
       return modifiers.union(specialKeysState.mouseModifiers)
     }
+
+  public fun handleServerEvent(serverEvent: ServerEvent) {
+    if (serverEvent is ServerCaretInfoChangedEvent && inputMethod is ImeInputMethod) {
+      inputMethod.handleServerCaretInfoChangedEvent(serverEvent)
+    }
+  }
 
   private companion object {
 

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/InputController.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/InputController.kt
@@ -33,10 +33,10 @@ import org.jetbrains.projector.client.web.misc.toScrollingMode
 import org.jetbrains.projector.client.web.state.ClientAction
 import org.jetbrains.projector.client.web.state.ClientStateMachine
 import org.jetbrains.projector.client.web.window.DragEventsInterceptor
+import org.jetbrains.projector.client.web.window.Positionable
 import org.jetbrains.projector.client.web.window.WindowManager
-import org.jetbrains.projector.common.protocol.toServer.*
-import org.jetbrains.projector.common.protocol.toClient.ServerEvent
 import org.jetbrains.projector.common.protocol.toClient.ServerCaretInfoChangedEvent
+import org.jetbrains.projector.common.protocol.toServer.*
 import org.w3c.dom.TouchEvent
 import org.w3c.dom.clipboard.ClipboardEvent
 import org.w3c.dom.events.Event
@@ -50,6 +50,7 @@ class InputController(
   private val openingTimeStamp: Int,
   private val stateMachine: ClientStateMachine,
   private val windowManager: WindowManager,
+  windowPositionByIdGetter: (windowId: Int) -> Positionable?,
 ) {
 
   private val specialKeysState = SpecialKeysState()
@@ -57,7 +58,7 @@ class InputController(
   private val inputMethod = { event: ClientEvent -> stateMachine.fire(ClientAction.AddEvent(event)) }.let {
     when (ParamsProvider.INPUT_METHOD_TYPE) {
       ParamsProvider.InputMethodType.LEGACY -> LegacyInputMethod(openingTimeStamp, specialKeysState, it)
-      ParamsProvider.InputMethodType.IME -> ImeInputMethod(openingTimeStamp, it)
+      ParamsProvider.InputMethodType.IME -> ImeInputMethod(openingTimeStamp, it, windowPositionByIdGetter)
       ParamsProvider.InputMethodType.OVERLAY_BUTTONS,
       -> MobileInputMethod(openingTimeStamp, specialKeysState, false, it)
       ParamsProvider.InputMethodType.OVERLAY_BUTTONS_N_VIRTUAL_KEYBOARD,
@@ -389,10 +390,8 @@ class InputController(
       return modifiers.union(specialKeysState.mouseModifiers)
     }
 
-  public fun handleServerEvent(serverEvent: ServerEvent) {
-    if (serverEvent is ServerCaretInfoChangedEvent && inputMethod is ImeInputMethod) {
-      inputMethod.handleServerCaretInfoChangedEvent(serverEvent)
-    }
+  fun handleCaretInfoChange(caretInfoChange: ServerCaretInfoChangedEvent.CaretInfoChange) {
+    inputMethod.handleCaretInfoChange(caretInfoChange)
   }
 
   private companion object {

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/ImeInputMethod.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/ImeInputMethod.kt
@@ -30,6 +30,7 @@ import org.jetbrains.projector.common.protocol.toServer.ClientKeyEvent.KeyEventT
 import org.jetbrains.projector.common.protocol.toServer.ClientKeyEvent.KeyEventType.UP
 import org.jetbrains.projector.common.protocol.toServer.ClientKeyPressEvent
 import org.jetbrains.projector.common.protocol.toServer.KeyModifier
+import org.jetbrains.projector.common.protocol.toClient.ServerCaretInfoChangedEvent
 import org.w3c.dom.HTMLTextAreaElement
 import org.w3c.dom.events.CompositionEvent
 import org.w3c.dom.events.Event
@@ -51,8 +52,7 @@ class ImeInputMethod(
   private val inputField = (document.createElement("textarea") as HTMLTextAreaElement).apply {
     style.apply {
       position = "fixed"
-      bottom = "-30%"
-      left = "50%"
+      opacity = "0"
     }
 
     autocomplete = "off"
@@ -91,6 +91,19 @@ class ImeInputMethod(
 
   override fun dispose() {
     inputField.remove()
+  }
+
+  fun handleServerCaretInfoChangedEvent(serverEvent: ServerCaretInfoChangedEvent) {
+    val carets = serverEvent.data as ServerCaretInfoChangedEvent.CaretInfoChange.Carets
+    val caretInfo = carets.caretInfoList[0]
+    val x = caretInfo.locationInWindow.x
+    val y = caretInfo.locationInWindow.y
+
+    inputField.style.apply {
+      top = "${y}px"
+      left = "${x}px"
+      fontSize = "${carets.fontSize}px"
+    }
   }
 }
 

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/ImeInputMethod.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/ImeInputMethod.kt
@@ -106,8 +106,7 @@ class ImeInputMethod(
   override fun handleCaretInfoChange(caretInfoChange: ServerCaretInfoChangedEvent.CaretInfoChange) {
     fun resetInputFieldPosition() {
       inputField.style.apply {
-        removeProperty("top")
-        bottom = "-30%"
+        top = "-30%"
         left = "50%"
       }
     }

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/InputMethod.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/InputMethod.kt
@@ -23,7 +23,10 @@
  */
 package org.jetbrains.projector.client.web.input.key
 
+import org.jetbrains.projector.common.protocol.toClient.ServerCaretInfoChangedEvent
+
 interface InputMethod {
 
   fun dispose()
+  fun handleCaretInfoChange(caretInfoChange: ServerCaretInfoChangedEvent.CaretInfoChange)
 }

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/LegacyInputMethod.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/LegacyInputMethod.kt
@@ -25,6 +25,7 @@ package org.jetbrains.projector.client.web.input.key
 
 import kotlinx.browser.document
 import org.jetbrains.projector.client.web.input.SpecialKeysState
+import org.jetbrains.projector.common.protocol.toClient.ServerCaretInfoChangedEvent
 import org.jetbrains.projector.common.protocol.toServer.ClientEvent
 import org.jetbrains.projector.common.protocol.toServer.ClientKeyEvent.KeyEventType.DOWN
 import org.jetbrains.projector.common.protocol.toServer.ClientKeyEvent.KeyEventType.UP
@@ -50,5 +51,9 @@ class LegacyInputMethod(
     documentActionListeners.forEach { (type, handler) ->
       document.removeEventListener(type, handler)
     }
+  }
+
+  override fun handleCaretInfoChange(caretInfoChange: ServerCaretInfoChangedEvent.CaretInfoChange) {
+    // nop
   }
 }

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/MobileInputMethod.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/MobileInputMethod.kt
@@ -30,6 +30,7 @@ import org.jetbrains.projector.client.web.input.JsKey
 import org.jetbrains.projector.client.web.input.SpecialKeysState
 import org.jetbrains.projector.client.web.misc.toDisplayType
 import org.jetbrains.projector.common.protocol.data.VK
+import org.jetbrains.projector.common.protocol.toClient.ServerCaretInfoChangedEvent
 import org.jetbrains.projector.common.protocol.toServer.ClientEvent
 import org.jetbrains.projector.common.protocol.toServer.ClientKeyEvent
 import org.jetbrains.projector.common.protocol.toServer.ClientKeyEvent.KeyEventType.DOWN
@@ -346,6 +347,10 @@ class MobileInputMethod(
     if (supportVirtualKeyboard) {
       document.removeEventListener("selectionchange", this::handleVirtualKeyboardSelection)
     }
+  }
+
+  override fun handleCaretInfoChange(caretInfoChange: ServerCaretInfoChangedEvent.CaretInfoChange) {
+    // todo
   }
 
   private class ToggleButton(

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
@@ -430,7 +430,7 @@ sealed class ClientState {
         val decompressTimeStamp = TimeStamp.current
         val commands = decoder.decode(decompressed)
         val decodeTimestamp = TimeStamp.current
-        serverEventsProcessor.process(commands, pingStatistics, typing, markdownPanelManager)
+        serverEventsProcessor.process(commands, pingStatistics, typing, markdownPanelManager, inputController)
         val drawTimestamp = TimeStamp.current
 
         ImageCacher.collectGarbage()

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
@@ -387,7 +387,8 @@ sealed class ClientState {
     private val inputController = InputController(
       openingTimeStamp = openingTimeStamp,
       stateMachine = stateMachine,
-      windowManager = windowManager
+      windowManager = windowManager,
+      windowPositionByIdGetter = windowManager::get,
     ).apply {
       addListeners()
     }

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/Window.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/Window.kt
@@ -48,7 +48,13 @@ import org.jetbrains.projector.common.protocol.toServer.ResizeDirection
 import org.w3c.dom.HTMLCanvasElement
 import kotlin.math.roundToInt
 
-class Window(windowData: WindowData, private val stateMachine: ClientStateMachine) : LafListener {
+interface Positionable {
+
+  val bounds: CommonRectangle
+  val zIndex: Int
+}
+
+class Window(windowData: WindowData, private val stateMachine: ClientStateMachine) : LafListener, Positionable {
 
   val id = windowData.id
 
@@ -86,7 +92,7 @@ class Window(windowData: WindowData, private val stateMachine: ClientStateMachin
 
   private val commandProcessor = SingleRenderingSurfaceProcessor(renderingSurface)
 
-  var bounds: CommonRectangle = CommonRectangle(0.0, 0.0, 0.0, 0.0)
+  override var bounds: CommonRectangle = CommonRectangle(0.0, 0.0, 0.0, 0.0)
     set(value) {
       if (field == value) {
         return
@@ -95,7 +101,7 @@ class Window(windowData: WindowData, private val stateMachine: ClientStateMachin
       applyBounds()
     }
 
-  var zIndex: Int = 0
+  override var zIndex: Int = 0
     set(value) {
       if (field != value) {
         field = value


### PR DESCRIPTION
@ARTI1208, could you please take a look since it's similar to speculative typing.

cc @zh-h (#43)

This PR finalizes initial support for correct overlay position for IME.

Further steps:
* Add integration tests (it's possible to do it only after merging [int-test-low-level-keyboard](https://github.com/JetBrains/projector-client/tree/int-test-low-level-keyboard) branch).
* Resolve TODOs left in code (many places will be possible to be covered after resolving the same problems in speculative typing).
* Of course fix bugs if there are any.