### PR TITLE
Ci new release builder

### DIFF
--- a/.github/launcher-release-drafter.yml
+++ b/.github/launcher-release-drafter.yml
@@ -1,0 +1,24 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+exclude-labels:
+  - 'skip-changelog'
+include-labels:
+  - 'launcher:feature'
+  - 'launcher:fix'
+  - 'launcher:bug'
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'launcher:feature'
+
+  - title: '🐛 Fixes'
+    labels:
+      - 'launcher:fix'
+      - 'launcher:bug'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+  $CHANGES
+  ## Contributors
+  $CONTRIBUTORS

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,29 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+exclude-labels:
+  - 'skip-changelog'
+include-labels:
+  - 'client:feature'
+  - 'client:fix'
+  - 'client:bug'
+  - 'client:tests'
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'client:feature'
+
+  - title: '🐛 Fixes'
+    labels:
+      - 'client:fix'
+      - 'client:bug'
+
+  - title: '✅ Tests'
+    labels:
+      - 'client:tests'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+  $CHANGES
+  ## Contributors
+  $CONTRIBUTORS

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: zwaldowski/match-label-action@v2
         with:
-          allowed: 'client:feature, client:fix, client:bug, client:tests'
+          allowed: 'client:feature, client:fix, client:bug, client:tests, launcher:feature, launcher:fix, launcher:bug, ci'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Verify type labels"
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zwaldowski/match-label-action@v2
+        with:
+          allowed: 'client:feature, client:fix, client:bug, client:tests'

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,4 +1,4 @@
-name: Upload Release Asset
+name: "Create client draft release"
 
 on:
   push:
@@ -6,10 +6,20 @@ on:
       - "v*"
 
 jobs:
-  main:
-    name: Upload Release Asset
+  client_draft_release:
     runs-on: ubuntu-latest
     steps:
+      - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
+        id: tag_name
+        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+      - name: create draft release
+        id: create_release
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: Release ${{ steps.tag_name.outputs.SOURCE_TAG }}
+          tag: ${{ steps.tag_name.outputs.SOURCE_TAG }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Java
@@ -21,19 +31,6 @@ jobs:
           ./gradlew :projector-client-web:browserProductionWebpack
           cd projector-client-web/build/distributions
           zip -r ../projector-client-web-distribution.zip . -x *.map
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
-        id: tag_name
-        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -19,21 +19,18 @@ jobs:
       - run: sudo apt update && sudo apt install wine-stable -y
       - name: Build project
         run: ./gradlew :projector-launcher:distZip
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-          body: Changelog is available in [CHANGELOG.md](https://github.com/JetBrains/projector-client/blob/master/projector-launcher/CHANGELOG.md).
       - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
         id: tag_name
         run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-
+      - name: create draft release
+        id: create_release
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-name: launcher-release-drafter.yml
+          name: Release ${{ steps.tag_name.outputs.SOURCE_TAG }}
+          tag: ${{ steps.tag_name.outputs.SOURCE_TAG }}
       - name: Upload Release Asset (darwin-x64)
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
It is a new release builder.
How does it work?
Look at that:
```yml
on:
  push:
    tags:
      - "v*"
```
```yml
on:
  push:
    tags:
      - "launcher-v*"
 ```
After you pushed with tag `v*` or `launcher-v*` trigger starts. The bot creates a new draft release, following the pattern provided in the `*release-drafter.yml`.  The bot will collect labeled pull requests and place them in the changelog according to the pattern. After the bot creates a draft release, you can find it in the "releases" tab at the root of the repository. You can correct the changelog. After that, you need to tap the `release` button.