### PR TITLE
Add ability to reference IDEA classes in packages starting with "org.jetbrains."

### DIFF
--- a/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/ProjectorClassLoader.kt
+++ b/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/ProjectorClassLoader.kt
@@ -51,6 +51,8 @@ public class ProjectorClassLoader constructor(parent: ClassLoader? = null) : Cla
 
   private val forceLoadByOurselves = mutableSetOf<String>()
 
+  private val forceLoadByIdea = mutableSetOf<String>()
+
   private val jarFiles = mutableSetOf<String>()
 
   init {
@@ -67,8 +69,14 @@ public class ProjectorClassLoader constructor(parent: ClassLoader? = null) : Cla
     forceLoadByOurselves += className
   }
 
+  @Suppress("unused", "RedundantVisibilityModifier") // public to be accessible for additional setup
+  public fun forceLoadByIdea(className: String) {
+    forceLoadByIdea += className
+  }
+
   private fun mustBeLoadedByPlatform(name: String): Boolean = forceLoadByPlatform.any { name.startsWith(it) }
   private fun mustBeLoadedByOurselves(name: String): Boolean = forceLoadByOurselves.any { name.startsWith(it) }
+  private fun mustBeLoadedByIdea(name: String): Boolean = forceLoadByIdea.any { name.startsWith(it) }
 
   private fun isProjectorAgentClass(name: String): Boolean = name.startsWith(PROJECTOR_AGENT_PACKAGE_PREFIX)
   private fun isProjectorClass(name: String): Boolean = name.startsWith(PROJECTOR_PACKAGE_PREFIX) && name != javaClass.name
@@ -95,7 +103,7 @@ public class ProjectorClassLoader constructor(parent: ClassLoader? = null) : Cla
           }
         }
         mustBeLoadedByOurselves(name) -> defineClass(name, resolve, ::getResourceAsStream)
-        isIntellijClass(name) -> myIdeaLoader.loadClass(name, resolve)
+        isIntellijClass(name) || mustBeLoadedByIdea(name) -> myIdeaLoader.loadClass(name, resolve)
         else -> myAppClassLoader.loadClass(name, resolve)
       }
     }

--- a/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/ProjectorClassLoader.kt
+++ b/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/ProjectorClassLoader.kt
@@ -72,7 +72,7 @@ public class ProjectorClassLoader constructor(parent: ClassLoader? = null) : Cla
 
   private fun isProjectorAgentClass(name: String): Boolean = name.startsWith(PROJECTOR_AGENT_PACKAGE_PREFIX)
   private fun isProjectorClass(name: String): Boolean = name.startsWith(PROJECTOR_PACKAGE_PREFIX) && name != javaClass.name
-  private fun isIntellijClass(name: String): Boolean = name.startsWith(INTELLIJ_PACKAGE_PREFIX) && !isProjectorClass(name)
+  private fun isIntellijClass(name: String): Boolean = name.startsWith(INTELLIJ_PACKAGE_PREFIX) || (name.startsWith(JETBRAINS_PACKAGE_PREFIX) && !isProjectorClass(name))
 
   override fun loadClass(name: String, resolve: Boolean): Class<*> {
     synchronized(getClassLoadingLock(name)) {
@@ -154,6 +154,7 @@ public class ProjectorClassLoader constructor(parent: ClassLoader? = null) : Cla
   public companion object {
 
     private const val INTELLIJ_PACKAGE_PREFIX = "com.intellij."
+    private const val JETBRAINS_PACKAGE_PREFIX = "org.jetbrains."
     private const val PROJECTOR_PACKAGE_PREFIX = "org.jetbrains.projector."
     private const val PROJECTOR_AGENT_PACKAGE_PREFIX = "org.jetbrains.projector.agent."
 


### PR DESCRIPTION
Somehow missed that there are useful classes under "org.jetbrains." too. Only classes under "com.intellij." were considered as IDEA classes