### PR TITLE
PRJ-625 Fix Chromium int tests

### DIFF
--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/ImeInputMethod.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/key/ImeInputMethod.kt
@@ -71,6 +71,7 @@ class ImeInputMethod(
 
     onblur = {
       window.setTimeout(::focusInputField, 0) // https://stackoverflow.com/questions/7046798/jquery-focus-fails-on-firefox
+      focusInputField()  // make keyboard int tests work in Chromium
     }
 
     addEventListener("compositionstart", handler::handleEvent)


### PR DESCRIPTION
I've just noticed that after the fix of PRJ-625, some ime int tests are crashing because no keyboard events are received from the browser. This PR fixes it.