### PR TITLE
PRJ-658 Fix Projector plugin startup in IDEA 2021.2

### DIFF
--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/classloader/Setup.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/classloader/Setup.kt
@@ -35,7 +35,7 @@ public object ProjectorClassLoaderSetup {
     private set
 
   @Suppress("unused", "RedundantVisibilityModifier") // Called from projector-server, don't trigger linter that doesn't know it
-  public fun initClassLoader(classLoader: ClassLoader): ClassLoader {
+  public fun initClassLoader(classLoader: ClassLoader): ProjectorClassLoader {
     val prjClassLoader = if (classLoader is ProjectorClassLoader) classLoader else ProjectorClassLoader.instance
 
     // accessed in agent to get ide and projector classloaders in platform classloader context

--- a/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/ProjectorClassLoader.kt
+++ b/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/ProjectorClassLoader.kt
@@ -39,13 +39,6 @@ public class ProjectorClassLoader constructor(parent: ClassLoader? = null) : Cla
 
   private val loadMethod = ClassLoader::class.java.getDeclaredMethod("loadClass", String::class.java, Boolean::class.java).apply(Method::unprotect)
 
-  private val myAppClassLoader: ClassLoader by lazy {
-    ClassLoader::class.java
-      .getDeclaredMethod("getBuiltinAppClassLoader")
-      .apply(Method::unprotect)
-      .invoke(null) as ClassLoader
-  }
-
   private val myIdeaLoader: ClassLoader get() = ideaClassLoader ?: myAppClassLoader
 
   private val forceLoadByPlatform = mutableSetOf<String>()
@@ -177,6 +170,19 @@ public class ProjectorClassLoader constructor(parent: ClassLoader? = null) : Cla
     private const val PROJECTOR_AGENT_PACKAGE_PREFIX = "org.jetbrains.projector.agent."
 
     private val logger = Logger<ProjectorClassLoader>()
+
+    private val myAppClassLoader: ClassLoader by lazy {
+      val systemClassLoader = getSystemClassLoader()
+      // check we won't create infinite recursion when loading app classes
+      if (systemClassLoader.javaClass.name != ProjectorClassLoader::class.java.name) {
+        systemClassLoader
+      } else {
+        ClassLoader::class.java
+          .getDeclaredMethod("getBuiltinAppClassLoader")
+          .apply(Method::unprotect)
+          .invoke(null) as ClassLoader
+      }
+    }
 
     private var myInstance: ProjectorClassLoader? = null
 

--- a/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/ProjectorClassLoader.kt
+++ b/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/ProjectorClassLoader.kt
@@ -160,8 +160,12 @@ public class ProjectorClassLoader constructor(parent: ClassLoader? = null) : Cla
     return findInClassloaders { it.getResource(name) } ?: super.getResource(name)
   }
 
-  private fun appendToClassPathForInstrumentation(jarPath: String) {
+  public fun addJarSource(jarPath: String) {
     jarFiles += jarPath
+  }
+
+  private fun appendToClassPathForInstrumentation(jarPath: String) {
+    addJarSource(jarPath)
   }
 
   @Suppress("RedundantVisibilityModifier") // public so that `instance` is accessible for additional setup


### PR DESCRIPTION
In IDEA 2021.2 app startup script was updated and it now contains java.system.class.loader property, setting  com.intellij.util.lang.PathClassLoader as system ClassLoader, what was not expected when ProjectorClassLoader was initially implemented

Corresponding changes in server: https://github.com/JetBrains/projector-server/pull/66