### PR TITLE
Refactor server to support multiple transports natively

### DIFF
--- a/docSrc/src/doc/docs/ij_user_guide/server_customization.md
+++ b/docSrc/src/doc/docs/ij_user_guide/server_customization.md
@@ -116,6 +116,19 @@ If you want faster scrolling, you should decrease the value, so for example, the
 !!! bug
     Actually, we want to get rid of this option in the future, determining scrolling speed automatically, synced with the client. More details: [PRJ-272](https://youtrack.jetbrains.com/issue/PRJ-272).
 
+### Disabling WebSocket transport
+
+Name | Type | Default value
+---|---|---
+`ORG_JETBRAINS_PROJECTOR_SERVER_ENABLE_WS_TRANSPORT` | Boolean | `true`
+
+Setting this variable to false will disable the built-in web server and WebSocket transport.  
+Additional transports can be added at runtime via `ProjectorServer.addTransport`
+
+!!! warning
+    With default Projector distribution, this will leave you with no way to connect to it. This option is intended primarily for use with alternative embedding approaches.
+
+
 ## Difference between env vars and system props
 
 The advantage of specifying a system property is that it's not passed to a child process automatically.

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ClientEventHandler.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ClientEventHandler.kt
@@ -21,17 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.jetbrains.projector.server.core.websocket
+package org.jetbrains.projector.server.core
 
-import org.java_websocket.WebSocket
-import java.nio.ByteBuffer
-
-public abstract class TransportBuilder {
-  public lateinit var onError: (WebSocket?, Exception) -> Unit
-  public lateinit var onWsOpen: (connection: WebSocket) -> Unit
-  public lateinit var onWsClose: (connection: WebSocket) -> Unit
-  public lateinit var onWsMessageString: (connection: WebSocket, message: String) -> Unit
-  public lateinit var onWsMessageByteBuffer: (connection: WebSocket, message: ByteBuffer) -> Unit
-
-  public abstract fun build(): HttpWsTransport
+public interface ClientEventHandler {
+  public fun handleMessage(wrapper: ClientWrapper, message: String)
+  public fun onClientConnected(connection: ClientWrapper)
+  public fun onClientConnectionEnded(connection: ClientWrapper)
+  public fun updateClientsCount()
+  public fun getInitialClientState(address: String?): ClientSettings
 }

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ClientWrapper.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ClientWrapper.kt
@@ -21,35 +21,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.jetbrains.projector.server.core.websocket
+package org.jetbrains.projector.server.core
 
-import org.java_websocket.WebSocket
-import org.jetbrains.projector.server.core.ClientWrapper
-import org.jetbrains.projector.server.core.ServerTransport
-import java.nio.ByteBuffer
+import java.net.InetAddress
 
-public interface HttpWsTransport : ServerTransport {
-  public fun forEachWsConnection(action: (client: WebSocket) -> Unit)
+public interface ClientWrapper {
+  public var settings: ClientSettings
 
-  override fun forEachOpenedConnection(action: (client: ClientWrapper) -> Unit) {
-    forEachWsConnection {
-      val wrapper = it.getAttachment<ClientWrapper>() ?: return@forEachWsConnection
-      action(wrapper)
-    }
-  }
-
-  override val clientCount: Int
-    get() {
-      var count = 0
-      forEachWsConnection {
-        count++
-      }
-      return count
-    }
-
-  public fun onError(connection: WebSocket?, e: Exception)
-  public fun onWsOpen(connection: WebSocket)
-  public fun onWsClose(connection: WebSocket)
-  public fun onWsMessage(connection: WebSocket, message: String)
-  public fun onWsMessage(connection: WebSocket, message: ByteBuffer)
+  public fun send(data: ByteArray)
+  public fun disconnect(reason: String)
+  public val requiresConfirmation: Boolean
+  public val confirmationRemoteIp: InetAddress?
+  public val confirmationRemoteName: String
 }

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ServerTransport.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ServerTransport.kt
@@ -21,35 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.jetbrains.projector.server.core.websocket
+package org.jetbrains.projector.server.core
 
-import org.java_websocket.WebSocket
-import org.jetbrains.projector.server.core.ClientWrapper
-import org.jetbrains.projector.server.core.ServerTransport
-import java.nio.ByteBuffer
-
-public interface HttpWsTransport : ServerTransport {
-  public fun forEachWsConnection(action: (client: WebSocket) -> Unit)
-
-  override fun forEachOpenedConnection(action: (client: ClientWrapper) -> Unit) {
-    forEachWsConnection {
-      val wrapper = it.getAttachment<ClientWrapper>() ?: return@forEachWsConnection
-      action(wrapper)
-    }
-  }
-
-  override val clientCount: Int
-    get() {
-      var count = 0
-      forEachWsConnection {
-        count++
-      }
-      return count
-    }
-
-  public fun onError(connection: WebSocket?, e: Exception)
-  public fun onWsOpen(connection: WebSocket)
-  public fun onWsClose(connection: WebSocket)
-  public fun onWsMessage(connection: WebSocket, message: String)
-  public fun onWsMessage(connection: WebSocket, message: ByteBuffer)
+public interface ServerTransport {
+  public val clientCount: Int
+  public val wasStarted: Boolean
+  public fun start()
+  public fun stop(timeoutMs: Int = 0)
+  public fun forEachOpenedConnection(action: (client: ClientWrapper) -> Unit)
 }

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/classloader/Setup.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/classloader/Setup.kt
@@ -44,6 +44,10 @@ public object ProjectorClassLoaderSetup {
     prjClassLoader.forceLoadByPlatform(PanelUpdater::class.java.name)
     // without this server not works...
     prjClassLoader.forceLoadByPlatform("org.jetbrains.projector.server.core.websocket.")
+    prjClassLoader.forceLoadByPlatform("org.jetbrains.projector.server.core.ServerTransport")
+    prjClassLoader.forceLoadByPlatform("org.jetbrains.projector.server.core.ClientWrapper")
+    prjClassLoader.forceLoadByPlatform("org.jetbrains.projector.server.core.ClientSettings")
+    prjClassLoader.forceLoadByPlatform("org.jetbrains.projector.server.core.ClientEventHandler")
     // we need only version of this class loaded by platform
     prjClassLoader.forceLoadByPlatform("com.intellij.ide.WindowsCommandLineProcessor")
     // to access ideaClassLoaderInitialized field only from AppClassLoader context

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/HttpWsClient.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/HttpWsClient.kt
@@ -108,11 +108,11 @@ public abstract class HttpWsClient(
     controlWebSocket.connect()
   }
 
-  public override fun stop(timeout: Int) {
+  public override fun stop(timeoutMs: Int) {
     controlWebSocket.close()
   }
 
-  public override fun forEachOpenedConnection(action: (client: WebSocket) -> Unit) {
+  public override fun forEachWsConnection(action: (client: WebSocket) -> Unit) {
     clients.values.forEach {
       action(it)
     }

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/HttpWsClientBuilder.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/HttpWsClientBuilder.kt
@@ -26,7 +26,7 @@ package org.jetbrains.projector.server.core.websocket
 import org.java_websocket.WebSocket
 import java.nio.ByteBuffer
 
-public class HttpWsClientBuilder(private val relayUrl: String, private val serverId: String) : TransportBuilder() {
+public class HttpWsClientBuilder(private val relayUrl: String, private val serverId: String) : WsTransportBuilder() {
 
   override fun build(): HttpWsClient {
     return object : HttpWsClient(relayUrl, serverId) {

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/HttpWsServer.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/HttpWsServer.kt
@@ -41,7 +41,6 @@ import org.jetbrains.projector.util.logging.Logger
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
-import java.util.*
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -283,11 +282,11 @@ public abstract class HttpWsServer(host: InetAddress, port: Int) : HttpWsTranspo
     webSocketServer.start()
   }
 
-  override fun stop(timeout: Int) {
-    webSocketServer.stop(timeout)
+  override fun stop(timeoutMs: Int) {
+    webSocketServer.stop(timeoutMs)
   }
 
-  override fun forEachOpenedConnection(action: (client: WebSocket) -> Unit) {
+  override fun forEachWsConnection(action: (client: WebSocket) -> Unit) {
     webSocketServer.connections.filter(WebSocket::isOpen).forEach(action)
   }
 

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/HttpWsServerBuilder.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/HttpWsServerBuilder.kt
@@ -30,7 +30,7 @@ import org.jetbrains.projector.util.logging.Logger
 import java.net.InetAddress
 import java.nio.ByteBuffer
 
-public class HttpWsServerBuilder(private val host: InetAddress, private val port: Int): TransportBuilder() {
+public class HttpWsServerBuilder(private val host: InetAddress, private val port: Int): WsTransportBuilder() {
 
   public lateinit var getMainWindows: () -> List<MainWindow>
 

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/MultiTransport.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/MultiTransport.kt
@@ -24,6 +24,7 @@
 package org.jetbrains.projector.server.core.websocket
 
 import org.java_websocket.WebSocket
+import org.jetbrains.projector.server.core.ClientWrapper
 import java.nio.ByteBuffer
 
 public class MultiTransport(private val transports: List<HttpWsTransport>) : HttpWsTransport {
@@ -32,10 +33,19 @@ public class MultiTransport(private val transports: List<HttpWsTransport>) : Htt
 
   override fun start(): Unit = transports.forEach { it.start() }
 
-  override fun stop(timeout: Int): Unit = transports.forEach { it.stop(timeout) }
+  override fun stop(timeoutMs: Int): Unit = transports.forEach { it.stop(timeoutMs) }
 
-  override fun forEachOpenedConnection(action: (client: WebSocket) -> Unit) {
-    transports.forEach { it.forEachOpenedConnection(action) }
+  override fun forEachWsConnection(action: (client: WebSocket) -> Unit) {
+    transports.forEach { it.forEachWsConnection(action) }
+  }
+
+  override val clientCount: Int
+    get() = transports.sumOf { it.clientCount }
+
+  override fun forEachOpenedConnection(action: (client: ClientWrapper) -> Unit) {
+    transports.forEach {
+      it.forEachOpenedConnection(action)
+    }
   }
 
   override fun onError(connection: WebSocket?, e: Exception): Unit = transports.forEach { it.onError(connection, e) }

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/MultiTransportBuilder.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/MultiTransportBuilder.kt
@@ -23,13 +23,13 @@
  */
 package org.jetbrains.projector.server.core.websocket
 
-public class MultiTransportBuilder(private val builders: List<TransportBuilder>) : TransportBuilder() {
+public class MultiTransportBuilder(private val builders: List<WsTransportBuilder>) : WsTransportBuilder() {
   override fun build(): HttpWsTransport {
     val transports = builders.map { prepareBuilder(it) }.map { it.build() }
     return MultiTransport(transports)
   }
 
-  private fun prepareBuilder(builder: TransportBuilder) = builder.apply {
+  private fun prepareBuilder(builder: WsTransportBuilder) = builder.apply {
     onError = this@MultiTransportBuilder.onError
     onWsOpen = this@MultiTransportBuilder.onWsOpen
     onWsClose = this@MultiTransportBuilder.onWsClose

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/WsClientWrapper.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/WsClientWrapper.kt
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.projector.server.core.websocket
+
+import org.java_websocket.WebSocket
+import org.java_websocket.exceptions.WebsocketNotConnectedException
+import org.jetbrains.projector.server.core.ClientSettings
+import org.jetbrains.projector.server.core.ClientWrapper
+import org.jetbrains.projector.server.core.ClosedClientSettings
+import org.jetbrains.projector.util.logging.Logger
+import java.net.InetAddress
+
+public class WsClientWrapper(private val connection: WebSocket, initialSettings: ClientSettings): ClientWrapper {
+  override var settings: ClientSettings = initialSettings
+
+  override fun disconnect(reason: String) {
+    val normalClosureCode = 1000  // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#properties
+    val conn = connection
+    conn.close(normalClosureCode, reason)
+
+    val clientSettings = conn.getAttachment<ClientSettings>()!!
+    logger.info { "Disconnecting user ${clientSettings.address}. Reason: $reason" }
+    conn.setAttachment(
+      ClosedClientSettings(
+        connectionMillis = clientSettings.connectionMillis,
+        address = clientSettings.address,
+        reason = reason,
+      )
+    )
+  }
+
+  override fun send(data: ByteArray) {
+    try {
+      connection.send(data) // can cause a "disconnected already" exception
+    }
+    catch (e: WebsocketNotConnectedException) {
+      logger.debug(e) { "While generating message, client disconnected" }
+    }
+  }
+
+  override val requiresConfirmation: Boolean
+    get() {
+      val remoteAddress = connection.remoteSocketAddress?.address
+      return remoteAddress?.isLoopbackAddress != true
+    }
+
+  override val confirmationRemoteIp: InetAddress?
+    get() = connection.remoteSocketAddress?.address
+
+  override val confirmationRemoteName: String
+    get() = "unknown host"
+
+  private companion object {
+    private val logger = Logger<WsClientWrapper>()
+  }
+}

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/WsTransportBuilder.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/websocket/WsTransportBuilder.kt
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.projector.server.core.websocket
+
+import org.java_websocket.WebSocket
+import org.jetbrains.projector.server.core.ClientEventHandler
+import org.jetbrains.projector.server.core.ClientWrapper
+import org.jetbrains.projector.util.logging.Logger
+import java.nio.ByteBuffer
+
+public abstract class WsTransportBuilder {
+  public lateinit var onError: (WebSocket?, Exception) -> Unit
+  public lateinit var onWsOpen: (connection: WebSocket) -> Unit
+  public lateinit var onWsClose: (connection: WebSocket) -> Unit
+  public lateinit var onWsMessageString: (connection: WebSocket, message: String) -> Unit
+  public lateinit var onWsMessageByteBuffer: (connection: WebSocket, message: ByteBuffer) -> Unit
+
+  public abstract fun build(): HttpWsTransport
+
+  public fun attachDefaultServerEventHandlers(clientEventHandler: ClientEventHandler): WsTransportBuilder {
+    onWsMessageByteBuffer = { _, message ->
+      throw RuntimeException("Unsupported message type: $message")
+    }
+
+    onWsMessageString = { connection, message ->
+      clientEventHandler.handleMessage(connection.getAttachment(), message)
+    }
+
+    onWsClose = { connection ->
+      // todo: we need more informative message, add parameters to this method inside the superclass
+      clientEventHandler.updateClientsCount()
+      val wrapper = connection.getAttachment<ClientWrapper>()
+      if (wrapper != null) {
+        clientEventHandler.onClientConnectionEnded(wrapper)
+      } else {
+        logger.info {
+          val address = connection.remoteSocketAddress?.address?.hostAddress
+          "Client from address $address is disconnected. This client hasn't clientSettings. " +
+          "This usually happens when the handshake stage didn't have time to be performed " +
+          "(so it seems the client has been connected for a very short time)"
+        }
+      }
+    }
+
+    onWsOpen = { connection ->
+      val address = connection.remoteSocketAddress?.address?.hostAddress
+      val wrapper = WsClientWrapper(connection, clientEventHandler.getInitialClientState(address))
+      connection.setAttachment(wrapper)
+      logger.info { "$address connected." }
+      clientEventHandler.onClientConnected(wrapper)
+    }
+
+    onError = { _, e ->
+      logger.error(e) { "onError" }
+    }
+
+    return this
+  }
+
+  private companion object {
+    private val logger = Logger<HttpWsServerBuilder>()
+  }
+}


### PR DESCRIPTION
This allows adding and removing transports at runtime, and allows external transport implementations.
 Additionally, an option to disable the default websocket transport is available.

Linked server PR: [projector-server #71](https://github.com/JetBrains/projector-server/pull/71)