### PR TITLE
Clean up build logic

### DIFF
--- a/buildSrc/src/main/kotlin/publishOnSpace.kt
+++ b/buildSrc/src/main/kotlin/publishOnSpace.kt
@@ -26,31 +26,30 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.credentials
-import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.maven
+import org.gradle.kotlin.dsl.*
 
-public fun PublishingExtension.publishOnSpace(project: Project, fromComponent: String) {
-  if (fromComponent == "java") {
-    this.publications {
-      create<MavenPublication>("maven") {
-        pom {
-          url.set("https://github.com/JetBrains/projector-client")
-          licenses {
-            license {
-              name.set("MIT Licence")
-              url.set("https://github.com/JetBrains/projector-client/blob/master/LICENSE.txt")
+public fun Project.publishToSpace(fromComponent: String) {
+  configure<PublishingExtension> {
+    if (fromComponent == "java") {
+      publications {
+        create<MavenPublication>("maven") {
+          pom {
+            url.set("https://github.com/JetBrains/projector-client")
+            licenses {
+              license {
+                name.set("MIT Licence")
+                url.set("https://github.com/JetBrains/projector-client/blob/master/LICENSE.txt")
+              }
             }
           }
+          from(project.components[fromComponent])
         }
-        from(project.components[fromComponent])
       }
     }
-  }
-  this.repositories {
-    maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies") {
-      credentials(PasswordCredentials::class)
+    repositories {
+      maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies") {
+        credentials(PasswordCredentials::class)
+      }
     }
   }
 }

--- a/projector-agent-common/build.gradle.kts
+++ b/projector-agent-common/build.gradle.kts
@@ -27,28 +27,13 @@ plugins {
   jacoco
 }
 
-val jacocoVersion: String by project
-
-jacoco {
-  toolVersion = jacocoVersion
-}
-
-tasks.withType<JacocoReport> {
-  setupReporting(project)
-}
-
-tasks.test {
-  useJUnitPlatform()
-  finalizedBy(tasks.jacocoTestReport)
-}
+setupJacoco()
 
 kotlin {
   explicitApi()
 }
 
-publishing {
-  publishOnSpace(project, "java")
-}
+publishToSpace("java")
 
 val javassistVersion: String by project
 

--- a/projector-agent-ij-injector/build.gradle.kts
+++ b/projector-agent-ij-injector/build.gradle.kts
@@ -28,15 +28,7 @@ plugins {
   jacoco
 }
 
-val jacocoVersion: String by project
-
-jacoco {
-  toolVersion = jacocoVersion
-}
-
-tasks.withType<JacocoReport> {
-  setupReporting(project)
-}
+setupJacoco()
 
 kotlin {
   explicitApi()
@@ -70,9 +62,4 @@ tasks.withType<Jar> {
   exclude("META-INF/versions/9/module-info.class")
 
   from(inline(configurations.runtimeClasspath))
-}
-
-tasks.test {
-  useJUnitPlatform()
-  finalizedBy(tasks.jacocoTestReport)
 }

--- a/projector-agent-initialization/build.gradle.kts
+++ b/projector-agent-initialization/build.gradle.kts
@@ -1,15 +1,17 @@
 plugins {
   kotlin("jvm")
   `maven-publish`
+  jacoco
 }
 
 kotlin {
   explicitApi()
 }
 
-publishing {
-  publishOnSpace(project, "java")
-}
+publishToSpace("java")
+
+setupJacoco()
+
 val kotlinVersion: String by project
 
 dependencies {

--- a/projector-client-common/build.gradle.kts
+++ b/projector-client-common/build.gradle.kts
@@ -28,17 +28,9 @@ plugins {
   java
 }
 
-val jacocoVersion: String by project
-
-jacoco {
-  toolVersion = jacocoVersion
-}
+setupJacoco(isKotlinMpModule = true)
 
 val kotlinVersion: String by project
-
-tasks.withType<JacocoReport> {
-  setupReporting(project, isKotlinMpModule = true)
-}
 
 kotlin {
   js {
@@ -77,6 +69,4 @@ kotlin {
   }
 }
 
-publishing {
-  publishOnSpace(project, "kotlin")
-}
+publishToSpace("kotlin")

--- a/projector-common/build.gradle.kts
+++ b/projector-common/build.gradle.kts
@@ -29,18 +29,10 @@ plugins {
   java
 }
 
-val jacocoVersion: String by project
-
-jacoco {
-  toolVersion = jacocoVersion
-}
+setupJacoco(isKotlinMpModule = true)
 
 val kotlinVersion: String by project
 val serializationVersion: String by project
-
-tasks.withType<JacocoReport> {
-  setupReporting(project, isKotlinMpModule = true)
-}
 
 kotlin {
   js {
@@ -82,6 +74,4 @@ kotlin {
   }
 }
 
-publishing {
-  publishOnSpace(project, "kotlin")
-}
+publishToSpace("kotlin")

--- a/projector-server-core/build.gradle.kts
+++ b/projector-server-core/build.gradle.kts
@@ -36,19 +36,9 @@ kotlin {
   explicitApi()
 }
 
-val jacocoVersion: String by project
+setupJacoco()
 
-jacoco {
-  toolVersion = jacocoVersion
-}
-
-tasks.withType<JacocoReport> {
-  setupReporting(project)
-}
-
-publishing {
-  publishOnSpace(project, "java")
-}
+publishToSpace("java")
 
 val coroutinesVersion: String by project
 val dnsjavaVersion: String by project

--- a/projector-util-agent/build.gradle.kts
+++ b/projector-util-agent/build.gradle.kts
@@ -27,31 +27,16 @@ plugins {
   jacoco
 }
 
-val jacocoVersion: String by project
-
-jacoco {
-  toolVersion = jacocoVersion
-}
-
-tasks.withType<JacocoReport> {
-  setupReporting(project)
-}
+setupJacoco()
 
 kotlin {
   explicitApi()
 }
 
-publishing {
-  publishOnSpace(project, "java")
-}
+publishToSpace("java")
 
 dependencies {
   implementation(project(":projector-util-logging"))
 
   testImplementation(kotlin("test"))
-}
-
-tasks.test {
-  useJUnitPlatform()
-  finalizedBy(tasks.jacocoTestReport)
 }

--- a/projector-util-loading/build.gradle.kts
+++ b/projector-util-loading/build.gradle.kts
@@ -4,23 +4,13 @@ plugins {
   jacoco
 }
 
-val jacocoVersion: String by project
-
-jacoco {
-  toolVersion = jacocoVersion
-}
-
-tasks.withType<JacocoReport> {
-  setupReporting(project)
-}
+setupJacoco()
 
 kotlin {
   explicitApi()
 }
 
-publishing {
-  publishOnSpace(project, "java")
-}
+publishToSpace("java")
 
 dependencies {
   api(project(":projector-util-logging"))

--- a/projector-util-logging/build.gradle.kts
+++ b/projector-util-logging/build.gradle.kts
@@ -48,6 +48,4 @@ kotlin {
   }
 }
 
-publishing {
-  publishOnSpace(project, "kotlin")
-}
+publishToSpace("kotlin")


### PR DESCRIPTION
I resolve some comments from #62 myself in this PR. Also, I've just searched for `JacocoPluginExtension` on GitHub and found this: https://github.com/icarohs7/unox-buildsrc/blob/8448c4b/src/main/kotlin/JacocoExtensions.kt. It's even more concise, so I've changed `setupJacoco` and `publishToSpace` accordingly. Let's have a call if you have any questions.

Please check it. Also, I suggest doing the same changes in the `projector-server` repo.

Let's firstly merge this PR into #62 and then merge #62 into master.