### PR TITLE
ci add publishing on space not only master branch

### DIFF
--- a/.github/workflows/publish-on-space.yml
+++ b/.github/workflows/publish-on-space.yml
@@ -2,7 +2,7 @@ name: Publish on Space
 
 on:
   push:
-    branches: [master]
+    branches: [ master, publish_* ]
 
 jobs:
   publish:


### PR DESCRIPTION
now to publish artifacts to space, you need to name the branch "publish_*"