### PR TITLE
remove extra character when copy/paste

### DIFF
--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
@@ -506,8 +506,10 @@ sealed class ClientState {
           typing.addEventChar(event)
         }
 
-        eventsToSend.add(event)
-        messagingPolicy.onAddEvent()
+        if (!isCopyOrPasteEvent(event)) {
+          eventsToSend.add(event)
+          messagingPolicy.onAddEvent()
+        }
 
         this
       }
@@ -555,6 +557,17 @@ sealed class ClientState {
         reloadConnection("No messages from server for ${action.elapsedTimeMs} ms, retrying the connection...")
 
       else -> super.consume(action)
+    }
+
+    private fun isCopyOrPasteEvent(event: ClientEvent): Boolean {
+      return (event is ClientKeyPressEvent
+              && (KeyModifier.CTRL_KEY in event.modifiers
+                  || KeyModifier.META_KEY in event.modifiers
+                  || event.char.category == CharCategory.CONTROL)
+              && (event.char.toString() == "v"
+                  || event.char.toString() == "V"
+                  || event.char.toString() == "C"
+                  || event.char.toString() == "c"))
     }
 
     private fun reloadConnection(messageText: String): ClientState {


### PR DESCRIPTION
For [PRJ-380](https://youtrack.jetbrains.com/issue/PRJ-380) and [PRJ-426](https://youtrack.jetbrains.com/issue/PRJ-426), I believe that we can merely send copy/paste events to projector-server without the extra "c" and "v", aiming at avoiding the useless character displayed in the terminal.