### PR TITLE
Remove theme_color from manifest

### DIFF
--- a/projector-client-web/src/main/resources/manifest.webmanifest
+++ b/projector-client-web/src/main/resources/manifest.webmanifest
@@ -1,6 +1,5 @@
 {
   "background_color": "gray",
-  "theme_color": "green",
   "description": "Projector client for accessing Swing apps",
   "display": "fullscreen",
   "icons": [


### PR DESCRIPTION
Addresses https://youtrack.jetbrains.com/issue/PRJ-274.
Removing the `theme_color` will cause the window title bar in macOS to be the system default, based on the current system setting for appearance. Behavior on other operating systems is similar.
For reference, see https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color