### PR TITLE
Reimplement `Field.unprotect` with MethodHandles

### DIFF
--- a/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/Reflect.kt
+++ b/projector-util-loading/src/main/kotlin/org/jetbrains/projector/util/loading/Reflect.kt
@@ -23,6 +23,7 @@
  */
 package org.jetbrains.projector.util.loading
 
+import java.lang.invoke.MethodHandles
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -31,10 +32,12 @@ import java.lang.reflect.Modifier
 public fun Field.unprotect() {
   isAccessible = true
 
-  Field::class.java.getDeclaredField("modifiers").apply {
-    isAccessible = true
-    setInt(this@unprotect, this@unprotect.modifiers and Modifier.FINAL.inv())
-  }
+  val modifiersHandle = MethodHandles
+    .privateLookupIn(Field::class.java, MethodHandles.lookup())
+    .findVarHandle(Field::class.java, "modifiers", Int::class.java)
+
+  val newValue = this.modifiers and Modifier.FINAL.inv()
+  modifiersHandle.set(this, newValue)
 }
 
 @Suppress("RedundantVisibilityModifier") // used in other modules

--- a/projector-util-loading/src/test/kotlin/org/jetbrains/projector/util/loading/ReflectionTest.kt
+++ b/projector-util-loading/src/test/kotlin/org/jetbrains/projector/util/loading/ReflectionTest.kt
@@ -23,12 +23,41 @@
  */
 package org.jetbrains.projector.util.loading
 
+import java.lang.reflect.Modifier
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class DummyTest {
+class ReflectionTest {
+
+  private class TestClass {
+    @Suppress("unused")
+    private val unprotectMe = 0
+    @Suppress("unused")
+    private var unprotectMeToo = 0
+  }
+
   @Test
-  fun `dummy test for coverage building`() {
-    assertTrue(true)
+  fun testFieldUnprotectFinal() {
+    runFieldUnprotectTest("unprotectMe", true)
+  }
+
+  @Test
+  fun testFieldUnprotectNonFinal() {
+    runFieldUnprotectTest("unprotectMeToo", false)
+  }
+
+  private fun runFieldUnprotectTest(fieldName: String, isFinalByDefault: Boolean) {
+    val field = TestClass::class.java.getDeclaredField(fieldName)
+    val classInstance = TestClass()
+
+    assertFalse(field.canAccess(classInstance))
+    assertEquals(isFinalByDefault, Modifier.isFinal(field.modifiers))
+
+    field.unprotect()
+
+    assertTrue(field.canAccess(classInstance))
+    assertFalse(Modifier.isFinal(field.modifiers))
   }
 }


### PR DESCRIPTION
First step towards jdk17 support. Old one fails on jdk17, this works both with jdk11 and jdk17