### PR TITLE
Move RenderingQueue to projector-client-common

### DIFF
--- a/projector-client-common/src/commonMain/kotlin/org/jetbrains/projector/client/common/RenderingQueue.kt
+++ b/projector-client-common/src/commonMain/kotlin/org/jetbrains/projector/client/common/RenderingQueue.kt
@@ -21,16 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.jetbrains.projector.client.web
+package org.jetbrains.projector.client.common
 
-import org.jetbrains.projector.client.common.DrawEvent
-import org.jetbrains.projector.client.common.SingleRenderingSurfaceProcessor
 import org.jetbrains.projector.client.common.SingleRenderingSurfaceProcessor.Companion.shrinkByPaintEvents
-import org.jetbrains.projector.client.web.window.WindowManager
+import org.jetbrains.projector.client.common.window.WindowManager
 import org.jetbrains.projector.common.protocol.toClient.ServerDrawCommandsEvent
 import org.jetbrains.projector.util.logging.Logger
 
-class RenderingQueue(private val windowManager: WindowManager) {
+class RenderingQueue(private val windowManager: WindowManager<*>) {
 
   private val pendingDrawEvents = ArrayDeque<ShrunkDrawEvents>()
   private val newDrawEvents = ArrayDeque<ShrunkDrawEvents>()

--- a/projector-client-common/src/commonMain/kotlin/org/jetbrains/projector/client/common/window/Window.kt
+++ b/projector-client-common/src/commonMain/kotlin/org/jetbrains/projector/client/common/window/Window.kt
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.projector.client.common.window
+
+import org.jetbrains.projector.client.common.SingleRenderingSurfaceProcessor
+
+interface Window {
+  val commandProcessor: SingleRenderingSurfaceProcessor
+}

--- a/projector-client-common/src/commonMain/kotlin/org/jetbrains/projector/client/common/window/WindowManager.kt
+++ b/projector-client-common/src/commonMain/kotlin/org/jetbrains/projector/client/common/window/WindowManager.kt
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.projector.client.common.window
+
+import org.jetbrains.projector.client.common.misc.ImageCacher
+
+interface WindowManager<TWindow : Window>: Iterable<TWindow> {
+  operator fun get(windowId: Int): TWindow?
+  val imageCacher: ImageCacher
+}

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/ServerEventsProcessor.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/ServerEventsProcessor.kt
@@ -24,22 +24,21 @@
 package org.jetbrains.projector.client.web
 
 import kotlinx.browser.window
+import org.jetbrains.projector.client.common.RenderingQueue
 import org.jetbrains.projector.client.web.component.MarkdownPanelManager
-import org.jetbrains.projector.client.web.electron.isElectron
 import org.jetbrains.projector.client.web.input.InputController
 import org.jetbrains.projector.client.web.misc.PingStatistics
 import org.jetbrains.projector.client.web.speculative.Typing
 import org.jetbrains.projector.client.web.state.ProjectorUI
 import org.jetbrains.projector.client.web.window.OnScreenMessenger
 import org.jetbrains.projector.client.web.window.WindowDataEventsProcessor
-import org.jetbrains.projector.client.web.window.WindowManager
+import org.jetbrains.projector.client.web.window.WebWindowManager
 import org.jetbrains.projector.common.misc.Do
 import org.jetbrains.projector.common.protocol.toClient.*
 import org.jetbrains.projector.util.logging.Logger
-import org.w3c.dom.url.URL
 
 class ServerEventsProcessor(
-  private val windowManager: WindowManager,
+  private val windowManager: WebWindowManager,
   private val windowDataEventsProcessor: WindowDataEventsProcessor,
   private val renderingQueue: RenderingQueue,
 ) {

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/InputController.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/input/InputController.kt
@@ -34,7 +34,7 @@ import org.jetbrains.projector.client.web.state.ClientAction
 import org.jetbrains.projector.client.web.state.ClientStateMachine
 import org.jetbrains.projector.client.web.window.DragEventsInterceptor
 import org.jetbrains.projector.client.web.window.Positionable
-import org.jetbrains.projector.client.web.window.WindowManager
+import org.jetbrains.projector.client.web.window.WebWindowManager
 import org.jetbrains.projector.common.protocol.toClient.ServerCaretInfoChangedEvent
 import org.jetbrains.projector.common.protocol.toServer.*
 import org.w3c.dom.TouchEvent
@@ -49,7 +49,7 @@ import kotlin.math.roundToInt
 class InputController(
   private val openingTimeStamp: Int,
   private val stateMachine: ClientStateMachine,
-  private val windowManager: WindowManager,
+  private val windowManager: WebWindowManager,
   windowPositionByIdGetter: (windowId: Int) -> Positionable?,
 ) {
 

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/state/ClientState.kt
@@ -35,7 +35,7 @@ import org.jetbrains.projector.client.common.misc.ParamsProvider
 import org.jetbrains.projector.client.common.misc.TimeStamp
 import org.jetbrains.projector.client.common.protocol.KotlinxJsonToClientHandshakeDecoder
 import org.jetbrains.projector.client.common.protocol.KotlinxJsonToServerHandshakeEncoder
-import org.jetbrains.projector.client.web.RenderingQueue
+import org.jetbrains.projector.client.common.RenderingQueue
 import org.jetbrains.projector.client.web.ServerEventsProcessor
 import org.jetbrains.projector.client.web.WindowSizeController
 import org.jetbrains.projector.client.web.component.MarkdownPanelManager
@@ -50,7 +50,7 @@ import org.jetbrains.projector.client.web.ui.ReconnectionMessage
 import org.jetbrains.projector.client.web.ui.ReconnectionMessageProps
 import org.jetbrains.projector.client.web.window.OnScreenMessenger
 import org.jetbrains.projector.client.web.window.WindowDataEventsProcessor
-import org.jetbrains.projector.client.web.window.WindowManager
+import org.jetbrains.projector.client.web.window.WebWindowManager
 import org.jetbrains.projector.common.misc.Do
 import org.jetbrains.projector.common.protocol.MessageDecoder
 import org.jetbrains.projector.common.protocol.MessageEncoder
@@ -339,7 +339,7 @@ sealed class ClientState {
 
     private val eventsToSend = mutableListOf<ClientEvent>(ClientSetKeymapEvent(nativeKeymap))
 
-    private val windowManager = WindowManager(stateMachine, imageCacher)
+    private val windowManager = WebWindowManager(stateMachine, imageCacher)
 
     private val windowDataEventsProcessor = WindowDataEventsProcessor(windowManager)
 

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/WebWindow.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/WebWindow.kt
@@ -32,6 +32,7 @@ import org.jetbrains.projector.client.common.canvas.buffering.DoubleBufferedRend
 import org.jetbrains.projector.client.common.canvas.buffering.UnbufferedRenderingSurface
 import org.jetbrains.projector.client.common.misc.ImageCacher
 import org.jetbrains.projector.client.common.misc.ParamsProvider
+import org.jetbrains.projector.client.common.window.Window
 import org.jetbrains.projector.client.web.misc.toDisplayType
 import org.jetbrains.projector.client.web.misc.toJsCursorType
 import org.jetbrains.projector.client.web.state.ClientAction
@@ -55,7 +56,7 @@ interface Positionable {
   val zIndex: Int
 }
 
-class Window(windowData: WindowData, private val stateMachine: ClientStateMachine, imageCacher: ImageCacher) : LafListener, Positionable {
+class WebWindow(windowData: WindowData, private val stateMachine: ClientStateMachine, imageCacher: ImageCacher) : Window, LafListener, Positionable {
 
   val id = windowData.id
 
@@ -88,7 +89,7 @@ class Window(windowData: WindowData, private val stateMachine: ClientStateMachin
   private var headerHeight: Double = 0.0
   private val border = WindowBorder(windowData.resizable)
 
-  val commandProcessor = SingleRenderingSurfaceProcessor(renderingSurface, imageCacher)
+  override val commandProcessor = SingleRenderingSurfaceProcessor(renderingSurface, imageCacher)
 
   override var bounds: CommonRectangle = CommonRectangle(0.0, 0.0, 0.0, 0.0)
     set(value) {

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/WindowDataEventsProcessor.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/WindowDataEventsProcessor.kt
@@ -34,7 +34,7 @@ import org.w3c.dom.HTMLImageElement
 import org.w3c.dom.HTMLLinkElement
 import kotlin.collections.isNotEmpty
 
-class WindowDataEventsProcessor(private val windowManager: WindowManager) {
+class WindowDataEventsProcessor(private val windowManager: WebWindowManager) {
 
   var excludedWindowIds = emptyList<Int>()
     private set
@@ -65,7 +65,7 @@ class WindowDataEventsProcessor(private val windowManager: WindowManager) {
         window.title = event.title
         window.isShowing = event.isShowing
         window.bounds = event.bounds
-        window.zIndex = (event.zOrder - presentedWindows.size) * WindowManager.zIndexStride
+        window.zIndex = (event.zOrder - presentedWindows.size) * WebWindowManager.zIndexStride
       }
     }
 
@@ -119,7 +119,7 @@ class WindowDataEventsProcessor(private val windowManager: WindowManager) {
 
   fun onResized() {
     synchronized(windowManager) {
-      windowManager.forEach(Window::applyBounds)
+      windowManager.forEach(WebWindow::applyBounds)
     }
   }
 

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/WindowHeader.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/WindowHeader.kt
@@ -49,7 +49,7 @@ class WindowHeader(var title: String? = null) : DragEventsInterceptor, LafListen
 
   private val canvas: HTMLCanvasElement = document.createElement("canvas") as HTMLCanvasElement
   private val style = canvas.style
-  private val headerRenderingSurface = Window.createRenderingSurface(canvas)
+  private val headerRenderingSurface = WebWindow.createRenderingSurface(canvas)
 
   private var dragStarted = false
   private var lastPoint = Point(-1.0, -1.0)


### PR DESCRIPTION
This includes abstracting WindowManager and Window as interfaces. This would allow for code reuse in non-web clients, i.e. Swing client.