### PR TITLE
Fix JB account login

### DIFF
--- a/projector-agent-ij-injector/src/main/kotlin/org/jetbrains/projector/agent/ijInjector/IjBrowserUtilTransformer.kt
+++ b/projector-agent-ij-injector/src/main/kotlin/org/jetbrains/projector/agent/ijInjector/IjBrowserUtilTransformer.kt
@@ -42,27 +42,15 @@ internal object IjBrowserUtilTransformer : IdeTransformerSetup<IjInjector.AgentP
   private fun transformBrowserUtil(clazz: CtClass): ByteArray {
 
     clazz
-      .getDeclaredMethod("browse", String::class.java)
-      .setBody(
-        // language=java prefix="class BrowserUtil { public static void browse(@NotNull String $1)" suffix="}"
-        """
-          {
-            if ($1.contains("account.jetbrains.com") && $1.contains("redirect_uri")) {
-              // fallback to token copy-pasting
-              throw new IllegalArgumentException("Automatic IDE licensing after login in JB account is disabled. This is an intended exception.");
-            }
-            java.net.URI uri = com.intellij.openapi.vfs.VfsUtil.toUri($1);
-            java.awt.Desktop.getDesktop().browse(uri);
-          }
-        """.trimIndent()
-      )
-
-    clazz
       .getDeclaredMethod("browse", String::class.java, Project::class.java)
       .setBody(
         // language=java prefix="class BrowserUtil { public static void browse(@NotNull String $1, @Nullable Project $2)" suffix="}"
         """
           {
+            if ($1.contains("account.jetbrains.com") && $1.contains("redirect_uri")) {
+              // fallback to token copy-pasting
+              throw new IllegalArgumentException("Automatic IDE licensing with JB account is unsupported. This is an intended exception.");
+            }
             java.net.URI uri = com.intellij.openapi.vfs.VfsUtil.toUri($1);
             java.awt.Desktop.getDesktop().browse(uri);
           }

--- a/projector-agent-ij-injector/src/main/kotlin/org/jetbrains/projector/agent/ijInjector/IjBrowserUtilTransformer.kt
+++ b/projector-agent-ij-injector/src/main/kotlin/org/jetbrains/projector/agent/ijInjector/IjBrowserUtilTransformer.kt
@@ -47,6 +47,10 @@ internal object IjBrowserUtilTransformer : IdeTransformerSetup<IjInjector.AgentP
         // language=java prefix="class BrowserUtil { public static void browse(@NotNull String $1)" suffix="}"
         """
           {
+            if ($1.contains("account.jetbrains.com") && $1.contains("redirect_uri")) {
+              // fallback to token copy-pasting
+              throw new IllegalArgumentException("Automatic IDE licensing after login in JB account is disabled. This is an intended exception.");
+            }
             java.net.URI uri = com.intellij.openapi.vfs.VfsUtil.toUri($1);
             java.awt.Desktop.getDesktop().browse(uri);
           }

--- a/projector-agent-ij-injector/src/main/kotlin/org/jetbrains/projector/agent/ijInjector/IjBrowserUtilTransformer.kt
+++ b/projector-agent-ij-injector/src/main/kotlin/org/jetbrains/projector/agent/ijInjector/IjBrowserUtilTransformer.kt
@@ -47,7 +47,8 @@ internal object IjBrowserUtilTransformer : IdeTransformerSetup<IjInjector.AgentP
         // language=java prefix="class BrowserUtil { public static void browse(@NotNull String $1)" suffix="}"
         """
           {
-            java.awt.Desktop.getDesktop().browse(new java.net.URI($1));
+            java.net.URI uri = com.intellij.openapi.vfs.VfsUtil.toUri($1);
+            java.awt.Desktop.getDesktop().browse(uri);
           }
         """.trimIndent()
       )
@@ -58,7 +59,8 @@ internal object IjBrowserUtilTransformer : IdeTransformerSetup<IjInjector.AgentP
         // language=java prefix="class BrowserUtil { public static void browse(@NotNull String $1, @Nullable Project $2)" suffix="}"
         """
           {
-            java.awt.Desktop.getDesktop().browse(new java.net.URI($1));
+            java.net.URI uri = com.intellij.openapi.vfs.VfsUtil.toUri($1);
+            java.awt.Desktop.getDesktop().browse(uri);
           }
         """.trimIndent()
       )

--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/electron/ElectronUtils.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/electron/ElectronUtils.kt
@@ -33,9 +33,14 @@ internal fun isElectron(): Boolean {
     return true
   }
 
-  // Main process
-  if (isDefined(process) && jsTypeOf(process.versions) == "object" && jsBoolean(process.versions.electron)) {
-    return true
+  try {
+    // Main process
+    if (isDefined(process) && jsTypeOf(process.versions) == "object" && jsBoolean(process.versions.electron)) {
+      return true
+    }
+  }
+  catch (_: Throwable) {
+    // Began to throw 'ReferenceError: process is not defined' after we switched to JS IR
   }
 
   // Detect the user agent when the `nodeIntegration` option is set to true


### PR DESCRIPTION
Now it opens browser for login automatically, so no copying is required (nice for running in insecure context).

For Linux/Windows host and MacOS client still requires Cmd+V (for clipboard sync) and then Ctrl+V (to actually paste on server). Will create ticket after this is merged