### PR TITLE
Add information about deprecation in Toolbox

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@
 bootstrapVersion=5.1.3
 coroutinesVersion=1.6.0
 dnsjavaVersion=3.4.3
-electronVersion=^15.2.0
+electronVersion=^16.0.6
 electronPackagerVersion=^15.1.0
 gradleMkdocsPluginVersion=2.2.0
 intellijPlatformVersion=213.6461.23

--- a/projector-launcher/CHANGELOG.md
+++ b/projector-launcher/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 Notable changes to this project are documented in this file.
 
-# Unreleased
+## Added
+
+# 1.1.0
 
 ## Added
 
-- Open DevTools by passing `--dev` flag
+- DevTools now can be opened by passing `--dev` flag on the command line
+- New warning dialog window: deprecation in Toolbox
 
 # 1.0.2
 

--- a/projector-launcher/README.md
+++ b/projector-launcher/README.md
@@ -36,3 +36,11 @@ After that, executables will be generated in the `build/electronOut` dir.
 ```shell script
 ./gradlew :projector-launcher:electronProductionRun
 ```
+
+### Development
+
+If you're a UI developer, and you want to speed up iterations when you constantly change HTML files, here are two new tasks introduced in 1.1.0: `electronRun` and `electronBuildAndRun`.
+
+The problem is, preparing the full dist environment with `electronProductionRun` takes unbelievably long time, therefore you can build only HTML and Kotlin (with `electronBuildAndRun`) or build nothing at all (`electronRun`).
+
+Please note, that the *fastest* way to get to do quick and dirty experiments with HTML and preload JS is to build the project only once (with `electronProductionRun`), then open the command line, change the directory to `build/distributions` and then run command `npx electron .`. You want to do this only if you work on quick fixing HTML. For building Kotlin, dependencies, and everything else `electronBuildAndRun` is still required.

--- a/projector-launcher/README.md
+++ b/projector-launcher/README.md
@@ -41,6 +41,8 @@ After that, executables will be generated in the `build/electronOut` dir.
 
 If you're a UI developer, and you want to speed up iterations when you constantly change HTML files, here are two new tasks introduced in 1.1.0: `electronRun` and `electronBuildAndRun`.
 
-The problem is, preparing the full dist environment with `electronProductionRun` takes unbelievably long time, therefore you can build only HTML and Kotlin (with `electronBuildAndRun`) or build nothing at all (`electronRun`).
+All three tasks are grouped into a new "development" group in Gradle. This means, if you use Gradle Plugin for IntelliJ, you can easily visually find it in a separate node of the tree, obviously called "development" too.
+
+The problem we're trying to solve with this: preparing the full dist environment with `electronProductionRun` takes unbelievably long time, therefore you can build only HTML and Kotlin (with `electronBuildAndRun`) or build nothing at all (`electronRun`).
 
 Please note, that the *fastest* way to get to do quick and dirty experiments with HTML and preload JS is to build the project only once (with `electronProductionRun`), then open the command line, change the directory to `build/distributions` and then run command `npx electron .`. You want to do this only if you work on quick fixing HTML. For building Kotlin, dependencies, and everything else `electronBuildAndRun` is still required.

--- a/projector-launcher/build.gradle.kts
+++ b/projector-launcher/build.gradle.kts
@@ -184,17 +184,20 @@ tasks.create("distZip") {
 }
 
 tasks.create<Exec>("electronProductionRun") {
+  group = "development"
   dependsOn(initDistEnvironment)
   workingDir(project.file(distDir))
   commandLine(npmCommand + listOf("run", "electron", "--", "."))
 }
 
 tasks.create<Exec>("electronRun") {
+  group = "development"
   workingDir(project.file(distDir))
   commandLine(npmCommand + listOf("run", "electron", "--", "."))
 }
 
 tasks.create<Exec>("electronBuildAndRun") {
+  group = "development"
   dependsOn(":projector-launcher:build")
   workingDir(project.file(distDir))
   commandLine(npmCommand + listOf("run", "electron", "--", "."))

--- a/projector-launcher/build.gradle.kts
+++ b/projector-launcher/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
   implementation("org.jetbrains.kotlin-wrappers:kotlin-extensions:$kotlinExtensionsVersion")
 }
 
-version = "1.0.2"  // todo: npm doesn't support versions like "1.0-SNAPSHOT"
+version = "1.1.0"  // npm doesn't support versions like "1.0-SNAPSHOT"
 
 val npmCommand = when (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
   true -> listOf("cmd.exe", "/C", "npm.cmd")

--- a/projector-launcher/build.gradle.kts
+++ b/projector-launcher/build.gradle.kts
@@ -188,3 +188,14 @@ tasks.create<Exec>("electronProductionRun") {
   workingDir(project.file(distDir))
   commandLine(npmCommand + listOf("run", "electron", "--", "."))
 }
+
+tasks.create<Exec>("electronRun") {
+  workingDir(project.file(distDir))
+  commandLine(npmCommand + listOf("run", "electron", "--", "."))
+}
+
+tasks.create<Exec>("electronBuildAndRun") {
+  dependsOn(":projector-launcher:build")
+  workingDir(project.file(distDir))
+  commandLine(npmCommand + listOf("run", "electron", "--", "."))
+}

--- a/projector-launcher/src/main/kotlin/ElectronApp.kt
+++ b/projector-launcher/src/main/kotlin/ElectronApp.kt
@@ -49,7 +49,6 @@ class ElectronApp(val url: String) {
   lateinit var mainWindowNextUrl: String
   var initialized = false
 
-
   fun navigateMainWindow(url: String) {
     GlobalScope.launch(block = {
       that.mainWindowNextUrl = url

--- a/projector-launcher/src/main/kotlin/ElectronApp.kt
+++ b/projector-launcher/src/main/kotlin/ElectronApp.kt
@@ -30,8 +30,6 @@ import kotlinx.coroutines.await
 import kotlinx.coroutines.launch
 import org.w3c.dom.url.URL
 
-external fun encodeURI(data: String): String
-
 @OptIn(DelicateCoroutinesApi::class)
 class ElectronApp(val url: String) {
   var that = this
@@ -39,7 +37,7 @@ class ElectronApp(val url: String) {
   var toolboxInfoWasActivated: Boolean = false
 
   var path = require("path")
-  var node_url = require("url")
+  //var node_url = require("url") //uncomment to enable "url" module
   var node_fs = require("fs")
 
   var app: App = Electron.app
@@ -135,7 +133,7 @@ class ElectronApp(val url: String) {
                                    didFailLoadListener = { _: Event, errorCode: Number, errorDescription: String, validatedURL: String, _: Boolean, _: Number, _: Number ->
                                      GlobalScope.launch(block = {
                                        if (!that.initialized) {
-                                         if (!validatedURL.isNullOrBlank()) {
+                                         if (!validatedURL.isBlank()) {
                                            messageInvalidURL(validatedURL)
                                          }
 
@@ -182,16 +180,8 @@ class ElectronApp(val url: String) {
     })
   }
 
-  fun loadMessage(message: String) {
-    GlobalScope.launch(block = {
-      that.mainWindow.loadURL("about:blank").await()
-      var html = "<body><h1>Invalid URL</h1><p>$message</p></body>"
-      that.mainWindow.loadURL("data:text/html;charset=utf-8," + encodeURI(html)).await()
-    })
-  }
-
   fun testUrl(url: String): Boolean {
-    var result: Boolean = true
+    var result = true
     try {
       URL(url)
     }
@@ -222,7 +212,7 @@ class ElectronApp(val url: String) {
     ipcMain.on("projector-dom-ready") { event, _ ->
       ElectronUtil.disableAllStandardShortcuts()
 
-      var defaultUrl = this.configData.defaultUrl
+      val defaultUrl = this.configData.defaultUrl
       if (null != defaultUrl) {
         event.sender.send("projector-set-url", defaultUrl)
       }
@@ -314,7 +304,7 @@ class ElectronApp(val url: String) {
   }
 
   fun savedb() {
-    var data = JSON.stringify(this.configData)
+    val data = JSON.stringify(this.configData)
 
     if (!node_fs.existsSync(GlobalSettings.USER_CONFIG_DIR)) {
       node_fs.mkdirSync(GlobalSettings.USER_CONFIG_DIR)
@@ -324,7 +314,7 @@ class ElectronApp(val url: String) {
 
   fun loaddb() {
     if (node_fs.existsSync(GlobalSettings.USER_CONFIG_FILE)) {
-      var buffer = node_fs.readFileSync(GlobalSettings.USER_CONFIG_FILE)
+      val buffer = node_fs.readFileSync(GlobalSettings.USER_CONFIG_FILE)
       this.configData = JSON.parse(buffer.toString())
     }
   }

--- a/projector-launcher/src/main/resources/assets/js/toolboxinfo.js
+++ b/projector-launcher/src/main/resources/assets/js/toolboxinfo.js
@@ -21,33 +21,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-external fun require(module: String): dynamic
-external val process: dynamic
-external val __dirname: dynamic
+window.onload = function () {
+  document.getElementById("ok-button").focus();
+};
 
-fun main() {
-  // Full Bootstrap CSS package
-  require("bootstrap/dist/css/bootstrap.min.css")
-  require("bootstrap/dist/css/bootstrap-grid.min.css")
-  require("bootstrap/dist/css/bootstrap-reboot.min.css")
-  require("bootstrap/dist/css/bootstrap-utilities.min.css")
+document.querySelector('#ok-button').addEventListener('click', function () {
+  connect()
+});
 
-  val argv = commandLineArguments()
-  var url = argv.last()
-
-  if (url.endsWith("projector.exe")) {
-    url = ""
-  }
-
-  if (argv.contains("--dev")) {
-    GlobalSettings.DEVELOPER_TOOLS_ENABLED = true
-  }
-
-  console.log("URL: $url")
-  val eapp = ElectronApp(url)
-  eapp.start()
-}
-
-fun commandLineArguments(): Array<String> {
-  return process.argv
+function connect() {
+  let checkboxValue = document.getElementById("dont-show-checkbox").checked;
+  const {ipcRenderer} = require('electron')
+  ipcRenderer.send("toolboxinfo-ok", checkboxValue);
 }

--- a/projector-launcher/src/main/resources/toolboxinfo.html
+++ b/projector-launcher/src/main/resources/toolboxinfo.html
@@ -1,0 +1,102 @@
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2019-2022 JetBrains s.r.o.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <base href="./">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <link href="favicon.ico" rel="icon" type="image/x-icon">
+  <link href="main.css" rel="stylesheet"> <!-- <- webpack output -->
+  <link crossorigin="anonymous" href="assets/css/styles.css" rel="stylesheet">
+  <title>Projector</title>
+</head>
+<body class="text-center">
+<div class="cover-container d-flex h-100 p-3 mx-auto flex-column">
+
+  <header class="stdhead mb-auto">
+    <div class="inner">
+      <h3 class="stdhead-brand"><a class="navbar-left" href="#"><img class="stdhead-brand-img" src="assets/img/pj512px.png"></a>Projector
+      </h3>
+      <nav class="nav nav-stdhead justify-content-center">
+        <a class="nav-link" href="https://github.com/JetBrains/projector-server">GitHub</a>
+        <a class="nav-link"
+           href="https://github.com/JetBrains/projector-server/blob/master/README-JETBRAINS.md">Readme</a>
+        <a class="nav-link" href="https://jetbrains.com">JetBrains</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="inner cover" role="main">
+    <div class="container cont-md">
+      <div class="row">
+        <div class="col-md-12 " style="padding-bottom: 20px;">
+
+          <div class="card w-75 bg-dark text-white text-start" style="margin: 0 auto; float: none; margin-bottom: 10px;">
+            <div class="card-body">
+              <h5 class="card-title text-center">Warning</h5>
+              <p class="card-text">
+              <p>
+                We will remove the Projector desktop app from the Toolbox in two weeks.
+              </p>
+              <p>
+                New versions of the app will be available on <a href="https://github.com/JetBrains/projector-client/releases">GitHub Releases</a>.
+              </p>
+              <p>
+                The primary <a href="https://www.jetbrains.com/remote-development/">Remote Development</a> tool for JetBrains IDEs is <a href="https://www.jetbrains.com/remote-development/gateway/">Gateway</a>. Gateway gives you the ability to work with minimal network latency, and setting up and administering the infrastructure is simpler than it is with Projector.<br>
+              </p>
+              <p>
+                Projector is a special solution for those who can't use Gateway. Projector has much higher network latency and is more difficult to configure, but it is the recommended solution if you want to access your IDEs from web browsers (including mobile browsers).
+              </p>
+              <p>
+                If you're not sure which solution you should choose, please consider using <a href="https://www.jetbrains.com/remote-development/gateway/">Gateway</a>.
+              </p>
+            </div>
+            <div class="card-text mb-3 mx-auto justify-content-center">
+              <div class="form-check mb-2">
+                <input class="form-check-input" type="checkbox" value="" id="dont-show-checkbox">
+                <label class="form-check-label" for="dont-show-checkbox">
+                  Don't show again
+                </label>
+              </div>
+              <button class="btn btn-primary" id="ok-button" >OK, I understand</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <footer class="stdfoot mt-auto">
+    <div class="inner">
+      <p></p>
+    </div>
+  </footer>
+
+</div>
+
+<script crossorigin="anonymous" type="module" src="assets/js/toolboxinfo.js"></script>
+</body>
+</html>

--- a/projector-launcher/src/main/resources/toolboxinfo.html
+++ b/projector-launcher/src/main/resources/toolboxinfo.html
@@ -58,28 +58,30 @@
               <h5 class="card-title text-center">Warning</h5>
               <p class="card-text">
               <p>
-                We will remove the Projector desktop app from the Toolbox in two weeks.
+                We will remove the Projector desktop app from <a href="https://jb.gg/projector-launcher-toolbox-deprecation-window-toolbox">JetBrains Toolbox</a> in roughly two weeks.
               </p>
               <p>
-                New versions of the app will be available on <a href="https://github.com/JetBrains/projector-client/releases">GitHub Releases</a>.
+                New versions of the app will be available on <a href="https://jb.gg/projector-launcher-toolbox-deprecation-window-ghreleases">GitHub Releases</a>.
               </p>
               <p>
-                The primary <a href="https://www.jetbrains.com/remote-development/">Remote Development</a> tool for JetBrains IDEs is <a href="https://www.jetbrains.com/remote-development/gateway/">Gateway</a>. Gateway gives you the ability to work with minimal network latency, and setting up and administering the infrastructure is simpler than it is with Projector.<br>
+                The primary <a href="https://jb.gg/projector-launcher-toolbox-deprecation-window-remote-development">remote development</a> tool for JetBrains IDEs is <a href="https://jb.gg/projector-launcher-toolbox-deprecation-window-gateway">Gateway</a>. Gateway gives you the ability to work with minimal network latency, and setting up the infrastructure and administering it is simpler than it is with Projector.<br>
               </p>
               <p>
                 Projector is a special solution for those who can't use Gateway. Projector has much higher network latency and is more difficult to configure, but it is the recommended solution if you want to access your IDEs from web browsers (including mobile browsers).
               </p>
               <p>
-                If you're not sure which solution you should choose, please consider using <a href="https://www.jetbrains.com/remote-development/gateway/">Gateway</a>.
+                If you're not sure which solution you should choose, please consider using <a href="https://jb.gg/projector-launcher-toolbox-deprecation-window-gateway">Gateway</a>.
               </p>
             </div>
             <div class="card-text mb-3 mx-auto justify-content-center">
               <div class="form-check mb-2">
                 <input class="form-check-input" type="checkbox" value="" id="dont-show-checkbox">
                 <label class="form-check-label" for="dont-show-checkbox">
-                  Don't show again
+                  Don’t show this message again
                 </label>
               </div>
+            </div>
+            <div class="card-text mb-4 mx-auto justify-content-center">
               <button class="btn btn-primary" id="ok-button" >OK, I understand</button>
             </div>
           </div>


### PR DESCRIPTION
This commits adds a new initial screen, explaining that Projector Launcher will eventually fade away from Toolbox.

It can be dismissed with the "don't show again" option that is stored in the preferences file in the home directory, it's the same place where the last URL is stored.