### PR TITLE
Prj 773 switch to kotest. Dummy tests refactoring

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,7 @@ javaWebSocketVersion=1.5.2
 jqueryVersion=3.6.0
 jsoupVersion=1.14.3
 karmaCoverageIstanbulReporter=3.0.3
+kotestVersion=5.1.0
 kotlinVersion=1.6.10
 kotlinExtensionsVersion=1.0.1-pre.284-kotlin-1.6.10
 kotlinReactVersion=17.0.2-pre.284-kotlin-1.6.10

--- a/projector-agent-common/build.gradle.kts
+++ b/projector-agent-common/build.gradle.kts
@@ -36,9 +36,11 @@ kotlin {
 publishToSpace("java")
 
 val javassistVersion: String by project
+val kotestVersion: String by project
 
 dependencies {
   implementation(project(":projector-util-loading"))
   implementation("org.javassist:javassist:$javassistVersion")
-  testImplementation(kotlin("test"))
+  testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+  testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
 }

--- a/projector-agent-common/src/test/kotlin/org/jetbrains/projector/agent/common/DummyTest.kt
+++ b/projector-agent-common/src/test/kotlin/org/jetbrains/projector/agent/common/DummyTest.kt
@@ -23,12 +23,6 @@
  */
 package org.jetbrains.projector.agent.common
 
-import kotlin.test.Test
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.StringSpec
 
-class MiscTest {
-  @Test
-  fun `empty test for coverage building`() {
-    assertTrue(true)
-  }
-}
+class DummyTest : StringSpec({ "empty test for coverage building" {} })

--- a/projector-agent-ij-injector/build.gradle.kts
+++ b/projector-agent-ij-injector/build.gradle.kts
@@ -38,6 +38,7 @@ val javassistVersion: String by project
 val intellijPlatformVersion: String by project
 val intellijMarkdownPluginVersion: String by project
 val intellijJcefVersion: String by project
+val kotestVersion: String by project
 
 dependencies {
   implementation(project(":projector-agent-common"))
@@ -52,7 +53,8 @@ dependencies {
   compileOnly("com.jetbrains.intellij.markdown:markdown:$intellijMarkdownPluginVersion")
   compileOnly("org.jetbrains.intellij.deps.jcef:jcef:$intellijJcefVersion")
 
-  testImplementation(kotlin("test"))
+  testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+  testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
 }
 
 val agentClass = "org.jetbrains.projector.agent.ijInjector.IjInjectorAgent"

--- a/projector-agent-ij-injector/src/test/kotlin/org/jetbrains/projector/agent/ijInjector/DummyTest.kt
+++ b/projector-agent-ij-injector/src/test/kotlin/org/jetbrains/projector/agent/ijInjector/DummyTest.kt
@@ -23,12 +23,6 @@
  */
 package org.jetbrains.projector.agent.ijInjector
 
-import kotlin.test.Test
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.StringSpec
 
-class DummyTest {
-  @Test
-  fun `dummy test for coverage building`() {
-    assertTrue(true)
-  }
-}
+class DummyTest : StringSpec({ "empty test for coverage building" {} })

--- a/projector-util-agent/build.gradle.kts
+++ b/projector-util-agent/build.gradle.kts
@@ -35,8 +35,11 @@ kotlin {
 
 publishToSpace("java")
 
+val kotestVersion: String by project
+
 dependencies {
   implementation(project(":projector-util-logging"))
 
-  testImplementation(kotlin("test"))
+  testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+  testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
 }

--- a/projector-util-agent/src/test/kotlin/org/jetbrains/projector/utill/agent/DummyTest.kt
+++ b/projector-util-agent/src/test/kotlin/org/jetbrains/projector/utill/agent/DummyTest.kt
@@ -23,12 +23,6 @@
  */
 package org.jetbrains.projector.utill.agent
 
-import kotlin.test.Test
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.StringSpec
 
-class DummyTest {
-  @Test
-  fun `dummy test for coverage building`() {
-    assertTrue(true)
-  }
-}
+class DummyTest : StringSpec({ "empty test for coverage building" {} })


### PR DESCRIPTION
The beginning of the switching to kotest. Rewriting dummy-tests.

- projector-agent-common
- projector-ij-injector
- projector-util-agent