### PR TITLE
PRJ-856 Temporarily add Sonarqube

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,33 @@ jobs:
     steps:
       - uses: browser-actions/setup-chrome@latest
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: gradle/wrapper-validation-action@v1
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: '11'
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
       - name: Clean
-        run: gradle clean
-      - name: Run Tests
+        run: ./gradlew clean
+      - name: Add JVM args for gradle
+        run: echo org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m >> gradle.properties
+      - name: Run Tests and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           sudo apt-get install numlockx xdotool
           export CHROME_BIN=/$(which chromium)
@@ -33,12 +52,8 @@ jobs:
           ./gradlew :projector-agent-ij-injector:jacocoTestReport
           ./gradlew :projector-client-common:jacocoTestReport
           ./gradlew :projector-util-agent:jacocoTestReport
+          ./gradlew sonarqube
 #          ./gradlew :projector-client-web:browserTest
-      - name: test coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./JacocoReports/
 
 # TODO: fix integration tests
 #  test-mac-os:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,15 +27,33 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 plugins {
   kotlin("multiplatform") apply false
   `maven-publish`
+  id("org.sonarqube")
 }
 
 val kotlinVersion: String by project
 val targetJvm: String by project
 val publishingVersion: String by project
 
+sonarqube {
+  properties {
+    property("sonar.projectKey", "Jetbrains_projector-client")
+    property("sonar.organization", "jetbrains")
+    property("sonar.host.url", "https://sonarcloud.io")
+  }
+}
+
 subprojects {
   group = "org.jetbrains.projector"
   version = publishingVersion
+
+  sonarqube {
+    properties {
+      property("sonar.sources", getSubprojectDirs("sources"))
+      property("sonar.tests", getSubprojectDirs("test"))
+      property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
+      property("sonar.host.url", "https://sonarcloud.io")
+    }
+  }
 
   repositories {
     mavenCentral()

--- a/buildSrc/src/main/kotlin/getSubprojectDirs.kt
+++ b/buildSrc/src/main/kotlin/getSubprojectDirs.kt
@@ -1,0 +1,46 @@
+import org.gradle.api.Project
+
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2022 JetBrains s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+public fun Project.getSubprojectDirs(dirType: String): String {
+  val srcMainDirs: MutableSet<String> = HashSet()
+  var matchResult: MatchResult?
+  projectDir.walk()
+    .filter { it.isDirectory }
+    .forEach {
+      when (dirType) {
+        "sources" -> {
+          matchResult = "src/(common|js|jvm)?[mM]ain".toRegex().find(it.absolutePath)
+          matchResult?.value?.split("/")?.last()?.let { dir -> srcMainDirs.add("src/$dir") }
+        }
+        "test" -> {
+          matchResult = "src/(common|int|jvm)?[tT]est".toRegex().find(it.absolutePath)
+          matchResult?.value?.split("/")?.last()?.let { dir -> srcMainDirs.add("src/$dir") }
+        }
+      }
+    }
+
+  return srcMainDirs.joinToString(",")
+}

--- a/buildSrc/src/main/kotlin/jacocoReport.kt
+++ b/buildSrc/src/main/kotlin/jacocoReport.kt
@@ -58,7 +58,6 @@ private fun JacocoReport.setup(project: Project, isKotlinMpModule: Boolean) {
 
   reports {
     xml.required.set(true)
-    xml.outputLocation.set(project.rootProject.file("JacocoReports/jacocoReport$moduleName.xml"))
     csv.required.set(false)
     html.outputLocation.set(project.layout.buildDirectory.dir("jacocoHtml$moduleName"))
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,6 +47,7 @@ radiumVersion=0.26.1
 reactLoadingIndicatorVersion=1.0.2
 selenideVersion=6.1.2
 serializationVersion=1.3.1
+sonarqubeVersion=3.3
 slf4jVersion=1.7.32
 targetJvm=11
 jacocoVersion=0.8.7

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ pluginManagement {
   val gradleMkdocsPluginVersion: String by settings
   val kotlinVersion: String by settings
   val symZipVersion: String by settings
+  val sonarqubeVersion: String by settings
 
   buildscript {
     repositories {
@@ -42,6 +43,7 @@ pluginManagement {
     kotlin("plugin.serialization") version kotlinVersion apply false
     id("org.paleozogt.symzip") version symZipVersion apply false
     id("ru.vyarus.mkdocs") version gradleMkdocsPluginVersion apply false
+    id("org.sonarqube") version sonarqubeVersion apply false
   }
 }
 


### PR DESCRIPTION
Temporarily, until Qodana starts to meet our requirements, we want to add an alternative means of automatic code review. For these purposes, Sonarqube was chosen.