### PR TITLE
PRJ-166 fix Compression

### DIFF
--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/protocol/GZipToClientMessageDecompressor.kt
+++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/protocol/GZipToClientMessageDecompressor.kt
@@ -29,10 +29,10 @@ import org.jetbrains.projector.common.protocol.handshake.CompressionType
 object GZipToClientMessageDecompressor : MessageDecompressor<ByteArray> {
 
   override fun decompress(data: ByteArray): ByteArray {
-    return pako.inflate(data) as ByteArray
+    return pako(data)
   }
 
   override val compressionType = CompressionType.GZIP
 
-  private val pako: dynamic = js("window.pako")
+  private val pako: dynamic = js("window.depress")
 }

--- a/projector-client-web/src/main/resources/index.html
+++ b/projector-client-web/src/main/resources/index.html
@@ -33,9 +33,12 @@
   <link href="styles.css" rel="stylesheet" type="text/css">
   <link href="manifest.webmanifest" rel="manifest">
   <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="192x192" >
-
-  <script src="https://cdn.jsdelivr.net/pako/1.0.3/pako.min.js"></script>
+  <script src="https://cdn.bootcss.com/pako/2.0.4/pako.min.js"></script>
   <script>
+    window.depress=(data)=> {
+      const decompressedData = pako.inflate(new Uint8Array(data.buffer))
+      return new Int8Array(decompressedData.buffer)
+    }
     // Disable caching for some scripts (described here: https://stackoverflow.com/questions/118884/how-to-force-the-browser-to-reload-cached-css-js-files):
     const timestamp = Math.floor(Date.now());
     const notCachableScripts = [


### PR DESCRIPTION
fix enableCompression param to use gzip 
the main reason is java compressed code  is int8 ,but the pako.inflate require uint8.
so do the transfer before and after pako.inflate 
[PRJ-166](https://youtrack.jetbrains.com/issue/PRJ-166)