### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -32,7 +32,7 @@ jobs:
           body: Changelog is available in [CHANGELOG.md](https://github.com/JetBrains/projector-client/blob/master/projector-launcher/CHANGELOG.md).
       - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
         id: tag_name
-        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+        run: echo SOURCE_TAG=${GITHUB_REF#refs/tags/} >> "$GITHUB_OUTPUT"
 
       - name: Upload Release Asset (darwin-x64)
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           body: Changelog is available in the server-side [CHANGELOG.md](https://github.com/JetBrains/projector-server/blob/master/projector-server/CHANGELOG.md).
       - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
         id: tag_name
-        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+        run: echo SOURCE_TAG=${GITHUB_REF#refs/tags/} >> "$GITHUB_OUTPUT"
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter